### PR TITLE
#17: Add palette to fix post composer styling

### DIFF
--- a/src/indie-settings/northskyTheme.ts
+++ b/src/indie-settings/northskyTheme.ts
@@ -1,17 +1,32 @@
 export const northskyDarkTheme = {
   palette: {
+    primary_25: 'red',
+    primary_50: 'yellow',
+    primary_100: '#38175A', // Hover background icons
+    primary_200: '#7780DC', // Disabled button background
+    primary_300: '#59B2CF', // Hover language selector
     primary_500: '#9A45EC', // Primary button background, link texts
+    primary_600: '#59B2CF', // Hover background primary button
   },
   atoms: {
     bg: {
       backgroundColor: '#1F0B35',
     },
+    bg_contrast_25: {
+      backgroundColor: '#38175A', // hover on clickable items
+    },
+    bg_contrast_50: {
+      backgroundColor: 'blue', // form background, hover clickable areas, secondary button
+    },
   },
 }
 
+// #122136 is new notficaitions background
+
 export const northskyLightTheme = {
   palette: {
-    primary_500: '#2AFBBA', // Primary button background, link texts
+    primary_500: '#9A45EC', // Primary button background, link texts
+    primary_600: '#59B2CF',
   },
   atoms: {
     bg: {


### PR DESCRIPTION
Add some palette definitions to improve the post composer styling:

Disabled post button:

<img width="912" height="390" alt="Screenshot 2026-04-10 at 18 22 43" src="https://github.com/user-attachments/assets/8e992580-388a-434e-b4c2-1f42373368cc" />

Enabled post button:

<img width="796" height="421" alt="Screenshot 2026-04-10 at 18 22 56" src="https://github.com/user-attachments/assets/176a3294-2072-4213-aaa6-39923d52598b" />
