### PR TITLE
#10 Slingshot to fetch missing records and avatar profiles

### DIFF
--- a/src/components/Post/Embed/SlingshotFallbackEmbed.tsx
+++ b/src/components/Post/Embed/SlingshotFallbackEmbed.tsx
@@ -1,0 +1,79 @@
+import {useMemo} from 'react'
+import {type $Typed, type AppBskyEmbedRecord} from '@atproto/api'
+import {Trans} from '@lingui/react/macro'
+
+import {isRecentTid, useSlingshotRecordQuery} from '#/state/queries/slingshot'
+import {type EmbedType} from '#/types/bsky/post'
+import {QuoteEmbed} from './index'
+import {PostPlaceholder as PostPlaceholderText} from './PostPlaceholder'
+import {type CommonProps} from './types'
+
+/**
+ * Renders a quoted post that the appview returned as "not found".
+ * If the post's TID is recent (< 7 days), attempts to fetch it
+ * from Slingshot. Otherwise falls back to the "Deleted" placeholder.
+ */
+export function SlingshotFallbackEmbed({
+  embed,
+  ...rest
+}: CommonProps & {
+  embed: EmbedType<'post_not_found'>
+}) {
+  const uri = embed.view.uri
+
+  // Extract rkey from at-uri to check recency
+  const rkey = useMemo(() => {
+    const parts = uri.split('/')
+    return parts.length >= 5 ? parts[4] : undefined
+  }, [uri])
+
+  const isRecent = rkey ? isRecentTid(rkey) : false
+
+  const {data: viewRecord, isLoading} = useSlingshotRecordQuery({
+    atUri: uri,
+    enabled: isRecent,
+  })
+
+  // Not recent enough — show "Deleted" immediately
+  if (!isRecent) {
+    return (
+      <PostPlaceholderText>
+        <Trans>Deleted</Trans>
+      </PostPlaceholderText>
+    )
+  }
+
+  // Still loading from Slingshot
+  if (isLoading) {
+    return (
+      <PostPlaceholderText>
+        <Trans>Loading...</Trans>
+      </PostPlaceholderText>
+    )
+  }
+
+  // Slingshot returned the record — render as a quote embed
+  if (viewRecord) {
+    const quoteEmbed: EmbedType<'post'> = {
+      type: 'post',
+      view: viewRecord as $Typed<AppBskyEmbedRecord.ViewRecord>,
+    }
+
+    return (
+      <QuoteEmbed
+        {...rest}
+        embed={quoteEmbed}
+        viewContext={undefined}
+        isWithinQuote={rest.isWithinQuote}
+        allowNestedQuotes={rest.allowNestedQuotes}
+      />
+    )
+  }
+
+  // Slingshot couldn't find it either — genuinely deleted
+  return (
+    <PostPlaceholderText>
+      <Trans>Deleted</Trans>
+    </PostPlaceholderText>
+  )
+}

--- a/src/components/Post/Embed/index.tsx
+++ b/src/components/Post/Embed/index.tsx
@@ -35,6 +35,7 @@ import {ModeratedFeedEmbed} from './FeedEmbed'
 import {ImageEmbed} from './ImageEmbed'
 import {ModeratedListEmbed} from './ListEmbed'
 import {PostPlaceholder as PostPlaceholderText} from './PostPlaceholder'
+import {SlingshotFallbackEmbed} from './SlingshotFallbackEmbed'
 import {
   type CommonProps,
   type EmbedProps,
@@ -174,11 +175,7 @@ function RecordEmbed({
       )
     }
     case 'post_not_found': {
-      return (
-        <PostPlaceholderText>
-          <Trans>Deleted</Trans>
-        </PostPlaceholderText>
-      )
+      return <SlingshotFallbackEmbed embed={embed} {...rest} />
     }
     case 'post_blocked': {
       return (

--- a/src/lib/slingshot/__tests__/blobs.test.ts
+++ b/src/lib/slingshot/__tests__/blobs.test.ts
@@ -1,0 +1,34 @@
+import {buildPdsBlobUrl} from '../blobs'
+
+describe('buildPdsBlobUrl', () => {
+  it('constructs correct getBlob URL', () => {
+    const url = buildPdsBlobUrl(
+      'https://pds.example.com',
+      'did:plc:abc123',
+      'bafyreiabc123',
+    )
+    expect(url).toBe(
+      'https://pds.example.com/xrpc/com.atproto.sync.getBlob?did=did%3Aplc%3Aabc123&cid=bafyreiabc123',
+    )
+  })
+
+  it('encodes special characters in DID', () => {
+    const url = buildPdsBlobUrl(
+      'https://pds.example.com',
+      'did:web:example.com:path',
+      'bafyreiabc',
+    )
+    expect(url).toContain('did=did%3Aweb%3Aexample.com%3Apath')
+  })
+
+  it('preserves PDS URL as-is', () => {
+    const url = buildPdsBlobUrl(
+      'https://my-pds.example.com:8080',
+      'did:plc:x',
+      'bafyrei123',
+    )
+    expect(url).toMatch(
+      /^https:\/\/my-pds\.example\.com:8080\/xrpc\/com\.atproto\.sync\.getBlob/,
+    )
+  })
+})

--- a/src/lib/slingshot/__tests__/client.test.ts
+++ b/src/lib/slingshot/__tests__/client.test.ts
@@ -1,0 +1,124 @@
+import {getRecordByUri, resolveMiniDoc, SLINGSHOT_SERVICE} from '../client'
+
+// Reset semaphore state between tests
+beforeEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('SLINGSHOT_SERVICE', () => {
+  it('points to Microcosm Slingshot', () => {
+    expect(SLINGSHOT_SERVICE).toBe('https://slingshot.microcosm.blue')
+  })
+})
+
+describe('getRecordByUri', () => {
+  it('returns record on successful fetch', async () => {
+    const mockRecord = {
+      uri: 'at://did:plc:abc/app.bsky.feed.post/3xyz',
+      cid: 'bafyrei123',
+      value: {$type: 'app.bsky.feed.post', text: 'hello'},
+    }
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockRecord,
+    } as Response)
+
+    const result = await getRecordByUri(
+      'at://did:plc:abc/app.bsky.feed.post/3xyz',
+    )
+    expect(result).toEqual(mockRecord)
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'blue.microcosm.repo.getRecordByUri?at_uri=at%3A%2F%2Fdid%3Aplc%3Aabc',
+      ),
+      expect.any(Object),
+    )
+  })
+
+  it('returns undefined on non-ok response', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    } as Response)
+
+    const result = await getRecordByUri('at://did:plc:abc/app.bsky.feed.post/x')
+    expect(result).toBeUndefined()
+  })
+
+  it('returns undefined on network error', async () => {
+    jest
+      .spyOn(global, 'fetch')
+      .mockRejectedValueOnce(new Error('Network error'))
+
+    const result = await getRecordByUri('at://did:plc:abc/app.bsky.feed.post/x')
+    expect(result).toBeUndefined()
+  })
+})
+
+describe('resolveMiniDoc', () => {
+  it('returns miniDoc on successful fetch', async () => {
+    const mockMiniDoc = {
+      did: 'did:plc:abc',
+      handle: 'alice.test',
+      pds: 'https://pds.example.com',
+      signing_key: 'did:key:z123',
+    }
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockMiniDoc,
+    } as Response)
+
+    const result = await resolveMiniDoc('did:plc:abc')
+    expect(result).toEqual(mockMiniDoc)
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'blue.microcosm.identity.resolveMiniDoc?identifier=did%3Aplc%3Aabc',
+      ),
+      expect.any(Object),
+    )
+  })
+
+  it('returns undefined on non-ok response', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    } as Response)
+
+    const result = await resolveMiniDoc('did:plc:abc')
+    expect(result).toBeUndefined()
+  })
+
+  it('returns undefined on network error', async () => {
+    jest
+      .spyOn(global, 'fetch')
+      .mockRejectedValueOnce(new Error('Network error'))
+
+    const result = await resolveMiniDoc('did:plc:abc')
+    expect(result).toBeUndefined()
+  })
+})
+
+describe('concurrency semaphore', () => {
+  it('allows up to 5 concurrent requests', async () => {
+    let inFlight = 0
+    let maxInFlight = 0
+
+    jest.spyOn(global, 'fetch').mockImplementation(async () => {
+      inFlight++
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      // Simulate async work
+      await new Promise(r => setTimeout(r, 50))
+      inFlight--
+      return {ok: true, json: async () => ({})} as Response
+    })
+
+    // Fire 10 concurrent requests
+    const promises = Array.from({length: 10}, (_, i) =>
+      getRecordByUri(`at://did:plc:abc/app.bsky.feed.post/${i}`),
+    )
+    await Promise.all(promises)
+
+    expect(maxInFlight).toBeLessThanOrEqual(5)
+    expect(maxInFlight).toBeGreaterThan(1) // Sanity: some parallelism happened
+  })
+})

--- a/src/lib/slingshot/__tests__/constellation.test.ts
+++ b/src/lib/slingshot/__tests__/constellation.test.ts
@@ -1,0 +1,155 @@
+import {CONSTELLATION_SERVICE, getPostInteractionCounts} from '../constellation'
+
+beforeEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('CONSTELLATION_SERVICE', () => {
+  it('points to Microcosm Constellation', () => {
+    expect(CONSTELLATION_SERVICE).toBe('https://constellation.microcosm.blue')
+  })
+})
+
+describe('getPostInteractionCounts', () => {
+  const postUri = 'at://did:plc:abc/app.bsky.feed.post/3xyz'
+
+  it('fetches all four counts in parallel', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch')
+    fetchSpy.mockImplementation(async (url: RequestInfo | URL) => {
+      const urlStr = url.toString()
+      if (urlStr.includes('app.bsky.feed.like')) {
+        return {ok: true, json: async () => ({count: 42})} as Response
+      }
+      if (urlStr.includes('app.bsky.feed.repost')) {
+        return {ok: true, json: async () => ({count: 7})} as Response
+      }
+      if (urlStr.includes('reply.parent.uri')) {
+        return {ok: true, json: async () => ({count: 3})} as Response
+      }
+      if (urlStr.includes('embed.record.uri')) {
+        return {ok: true, json: async () => ({count: 1})} as Response
+      }
+      return {ok: false} as Response
+    })
+
+    const counts = await getPostInteractionCounts(postUri)
+    expect(counts).toEqual({
+      likeCount: 42,
+      repostCount: 7,
+      replyCount: 3,
+      quoteCount: 1,
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(4)
+  })
+
+  it('calls correct Constellation endpoints', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch')
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({count: 0}),
+    } as Response)
+
+    await getPostInteractionCounts(postUri)
+
+    const calls = fetchSpy.mock.calls.map(c => c[0]?.toString())
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          'blue.microcosm.links.getBacklinksCount?subject=',
+        ),
+      ]),
+    )
+    // Verify each source type
+    expect(
+      calls.some(c => c?.includes('app.bsky.feed.like%3Asubject.uri')),
+    ).toBe(true)
+    expect(
+      calls.some(c => c?.includes('app.bsky.feed.repost%3Asubject.uri')),
+    ).toBe(true)
+    expect(
+      calls.some(c => c?.includes('app.bsky.feed.post%3Areply.parent.uri')),
+    ).toBe(true)
+    expect(
+      calls.some(c => c?.includes('app.bsky.feed.post%3Aembed.record.uri')),
+    ).toBe(true)
+  })
+
+  it('sends Accept: application/json header', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({count: 0}),
+    } as Response)
+
+    await getPostInteractionCounts(postUri)
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: {Accept: 'application/json'},
+      }),
+    )
+  })
+
+  it('returns 0 for failed requests', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 500,
+    } as Response)
+
+    const counts = await getPostInteractionCounts(postUri)
+    expect(counts).toEqual({
+      likeCount: 0,
+      repostCount: 0,
+      replyCount: 0,
+      quoteCount: 0,
+    })
+  })
+
+  it('returns 0 for network errors', async () => {
+    jest.spyOn(global, 'fetch').mockRejectedValue(new Error('Network error'))
+
+    const counts = await getPostInteractionCounts(postUri)
+    expect(counts).toEqual({
+      likeCount: 0,
+      repostCount: 0,
+      replyCount: 0,
+      quoteCount: 0,
+    })
+  })
+
+  it('returns 0 when count field is missing from response', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as Response)
+
+    const counts = await getPostInteractionCounts(postUri)
+    expect(counts).toEqual({
+      likeCount: 0,
+      repostCount: 0,
+      replyCount: 0,
+      quoteCount: 0,
+    })
+  })
+
+  it('handles partial failures gracefully', async () => {
+    let callCount = 0
+    jest.spyOn(global, 'fetch').mockImplementation(async () => {
+      callCount++
+      if (callCount === 1) {
+        return {ok: true, json: async () => ({count: 10})} as Response
+      }
+      if (callCount === 3) {
+        throw new Error('timeout')
+      }
+      return {ok: false, status: 500} as Response
+    })
+
+    const counts = await getPostInteractionCounts(postUri)
+    // First call succeeds (like=10), rest fail (=0)
+    expect(counts.likeCount).toBe(10)
+    expect(counts.repostCount).toBe(0)
+    expect(counts.replyCount).toBe(0)
+    expect(counts.quoteCount).toBe(0)
+  })
+})

--- a/src/lib/slingshot/__tests__/hydrate.test.ts
+++ b/src/lib/slingshot/__tests__/hydrate.test.ts
@@ -1,0 +1,280 @@
+import {
+  hydrateAvatarUrl,
+  hydratePostView,
+  hydratePostViewRecord,
+} from '../hydrate'
+import {type SlingshotMiniDoc} from '../types'
+
+const MOCK_MINIDOC: SlingshotMiniDoc = {
+  did: 'did:plc:testuser123',
+  handle: 'alice.test',
+  pds: 'https://pds.example.com',
+  signing_key: 'did:key:z123',
+}
+
+function makeBlobRef(cid: string, mimeType = 'image/jpeg', size = 1000) {
+  return {
+    $type: 'blob',
+    ref: {$link: cid},
+    mimeType,
+    size,
+  }
+}
+
+describe('hydratePostView', () => {
+  const BASE_URI = 'at://did:plc:testuser123/app.bsky.feed.post/3abc'
+  const BASE_CID = 'bafyreipost123'
+
+  it('hydrates a basic post without embeds', () => {
+    const record = {
+      $type: 'app.bsky.feed.post',
+      text: 'Hello world',
+      createdAt: '2026-04-10T12:00:00.000Z',
+    }
+    const view = hydratePostView(record, BASE_URI, BASE_CID, MOCK_MINIDOC)
+
+    expect(view.uri).toBe(BASE_URI)
+    expect(view.cid).toBe(BASE_CID)
+    expect(view.author.did).toBe('did:plc:testuser123')
+    expect(view.author.handle).toBe('alice.test')
+    expect(view.record).toBe(record)
+    expect(view.embed).toBeUndefined()
+    expect(view.replyCount).toBe(0)
+    expect(view.repostCount).toBe(0)
+    expect(view.likeCount).toBe(0)
+    expect(view.quoteCount).toBe(0)
+    expect(view.indexedAt).toBe('2026-04-10T12:00:00.000Z')
+  })
+
+  it('uses current time as indexedAt when createdAt missing', () => {
+    const before = new Date().toISOString()
+    const record = {$type: 'app.bsky.feed.post', text: 'test'}
+    const view = hydratePostView(record, BASE_URI, BASE_CID, MOCK_MINIDOC)
+    const after = new Date().toISOString()
+
+    expect(view.indexedAt >= before).toBe(true)
+    expect(view.indexedAt <= after).toBe(true)
+  })
+
+  it('hydrates image embeds with PDS blob URLs', () => {
+    const record = {
+      $type: 'app.bsky.feed.post',
+      text: 'pics',
+      createdAt: '2026-04-10T12:00:00.000Z',
+      embed: {
+        $type: 'app.bsky.embed.images',
+        images: [
+          {
+            image: makeBlobRef('bafyimg1'),
+            alt: 'first image',
+            aspectRatio: {width: 800, height: 600},
+          },
+          {
+            image: makeBlobRef('bafyimg2'),
+            alt: '',
+          },
+        ],
+      },
+    }
+    const view = hydratePostView(record, BASE_URI, BASE_CID, MOCK_MINIDOC)
+
+    expect(view.embed?.$type).toBe('app.bsky.embed.images#view')
+    const images = (view.embed as any).images
+    expect(images).toHaveLength(2)
+    expect(images[0].thumb).toContain('bafyimg1')
+    expect(images[0].fullsize).toContain('bafyimg1')
+    expect(images[0].alt).toBe('first image')
+    expect(images[0].aspectRatio).toEqual({width: 800, height: 600})
+    expect(images[1].thumb).toContain('bafyimg2')
+    expect(images[1].alt).toBe('')
+  })
+
+  it('hydrates external embeds with thumb blob URL', () => {
+    const record = {
+      $type: 'app.bsky.feed.post',
+      text: 'link',
+      createdAt: '2026-04-10T12:00:00.000Z',
+      embed: {
+        $type: 'app.bsky.embed.external',
+        external: {
+          uri: 'https://example.com/article',
+          title: 'Article Title',
+          description: 'A description',
+          thumb: makeBlobRef('bafythumb1'),
+        },
+      },
+    }
+    const view = hydratePostView(record, BASE_URI, BASE_CID, MOCK_MINIDOC)
+
+    expect(view.embed?.$type).toBe('app.bsky.embed.external#view')
+    const ext = (view.embed as any).external
+    expect(ext.uri).toBe('https://example.com/article')
+    expect(ext.title).toBe('Article Title')
+    expect(ext.description).toBe('A description')
+    expect(ext.thumb).toContain('bafythumb1')
+  })
+
+  it('hydrates external embed without thumb', () => {
+    const record = {
+      $type: 'app.bsky.feed.post',
+      text: 'link',
+      createdAt: '2026-04-10T12:00:00.000Z',
+      embed: {
+        $type: 'app.bsky.embed.external',
+        external: {
+          uri: 'https://example.com',
+          title: 'No Thumb',
+          description: '',
+        },
+      },
+    }
+    const view = hydratePostView(record, BASE_URI, BASE_CID, MOCK_MINIDOC)
+    const ext = (view.embed as any).external
+    expect(ext.thumb).toBeUndefined()
+  })
+
+  it('hydrates record embed as viewNotFound', () => {
+    const record = {
+      $type: 'app.bsky.feed.post',
+      text: 'quote',
+      createdAt: '2026-04-10T12:00:00.000Z',
+      embed: {
+        $type: 'app.bsky.embed.record',
+        record: {
+          uri: 'at://did:plc:other/app.bsky.feed.post/3xyz',
+          cid: 'bafyquoted',
+        },
+      },
+    }
+    const view = hydratePostView(record, BASE_URI, BASE_CID, MOCK_MINIDOC)
+
+    expect(view.embed?.$type).toBe('app.bsky.embed.record#view')
+    const inner = (view.embed as any).record
+    expect(inner.$type).toBe('app.bsky.embed.record#viewNotFound')
+    expect(inner.uri).toBe('at://did:plc:other/app.bsky.feed.post/3xyz')
+    expect(inner.notFound).toBe(true)
+  })
+
+  it('hydrates recordWithMedia embed', () => {
+    const record = {
+      $type: 'app.bsky.feed.post',
+      text: 'quote with media',
+      createdAt: '2026-04-10T12:00:00.000Z',
+      embed: {
+        $type: 'app.bsky.embed.recordWithMedia',
+        record: {
+          $type: 'app.bsky.embed.record',
+          record: {
+            uri: 'at://did:plc:other/app.bsky.feed.post/3xyz',
+            cid: 'bafyquoted',
+          },
+        },
+        media: {
+          $type: 'app.bsky.embed.images',
+          images: [
+            {
+              image: makeBlobRef('bafymedia1'),
+              alt: 'media',
+            },
+          ],
+        },
+      },
+    }
+    const view = hydratePostView(record, BASE_URI, BASE_CID, MOCK_MINIDOC)
+
+    expect(view.embed?.$type).toBe('app.bsky.embed.recordWithMedia#view')
+    const rwm = view.embed as any
+    expect(rwm.record.$type).toBe('app.bsky.embed.record#view')
+    expect(rwm.media.$type).toBe('app.bsky.embed.images#view')
+    expect(rwm.media.images[0].thumb).toContain('bafymedia1')
+  })
+
+  it('returns undefined embed for video (cannot hydrate)', () => {
+    const record = {
+      $type: 'app.bsky.feed.post',
+      text: 'video post',
+      createdAt: '2026-04-10T12:00:00.000Z',
+      embed: {
+        $type: 'app.bsky.embed.video',
+        video: makeBlobRef('bafyvideo', 'video/mp4', 50000),
+      },
+    }
+    const view = hydratePostView(record, BASE_URI, BASE_CID, MOCK_MINIDOC)
+    expect(view.embed).toBeUndefined()
+  })
+})
+
+describe('hydratePostViewRecord', () => {
+  it('returns ViewRecord with embeds array', () => {
+    const record = {
+      $type: 'app.bsky.feed.post',
+      text: 'test',
+      createdAt: '2026-04-10T12:00:00.000Z',
+      embed: {
+        $type: 'app.bsky.embed.images',
+        images: [{image: makeBlobRef('bafyimg'), alt: 'alt'}],
+      },
+    }
+    const vr = hydratePostViewRecord(
+      record,
+      'at://did:plc:testuser123/app.bsky.feed.post/3abc',
+      'bafyrei123',
+      MOCK_MINIDOC,
+    )
+
+    expect(vr.$type).toBe('app.bsky.embed.record#viewRecord')
+    expect(vr.value).toBe(record)
+    expect(vr.embeds).toHaveLength(1)
+    expect(vr.embeds![0].$type).toBe('app.bsky.embed.images#view')
+    expect(vr.replyCount).toBe(0)
+    expect(vr.likeCount).toBe(0)
+  })
+
+  it('returns undefined embeds when no embed in record', () => {
+    const record = {
+      $type: 'app.bsky.feed.post',
+      text: 'no embed',
+      createdAt: '2026-04-10T12:00:00.000Z',
+    }
+    const vr = hydratePostViewRecord(
+      record,
+      'at://did:plc:testuser123/app.bsky.feed.post/3abc',
+      'bafyrei123',
+      MOCK_MINIDOC,
+    )
+    expect(vr.embeds).toBeUndefined()
+  })
+})
+
+describe('hydrateAvatarUrl', () => {
+  it('returns PDS blob URL for profile avatar', () => {
+    const record = {
+      $type: 'app.bsky.actor.profile',
+      displayName: 'Alice',
+      avatar: makeBlobRef('bafyavatar'),
+    }
+    const url = hydrateAvatarUrl(record, MOCK_MINIDOC)
+    expect(url).toContain('bafyavatar')
+    expect(url).toContain('pds.example.com')
+    expect(url).toContain('com.atproto.sync.getBlob')
+  })
+
+  it('returns undefined for profile without avatar', () => {
+    const record = {
+      $type: 'app.bsky.actor.profile',
+      displayName: 'No Avatar',
+    }
+    const url = hydrateAvatarUrl(record, MOCK_MINIDOC)
+    expect(url).toBeUndefined()
+  })
+
+  it('returns undefined for post records', () => {
+    const record = {
+      $type: 'app.bsky.feed.post',
+      text: 'not a profile',
+      createdAt: '2026-04-10T12:00:00.000Z',
+    }
+    const url = hydrateAvatarUrl(record, MOCK_MINIDOC)
+    expect(url).toBeUndefined()
+  })
+})

--- a/src/lib/slingshot/__tests__/hydrate.test.ts
+++ b/src/lib/slingshot/__tests__/hydrate.test.ts
@@ -3,7 +3,7 @@ import {
   hydratePostView,
   hydratePostViewRecord,
 } from '../hydrate'
-import {type SlingshotMiniDoc} from '../types'
+import {type PostInteractionCounts, type SlingshotMiniDoc} from '../types'
 
 const MOCK_MINIDOC: SlingshotMiniDoc = {
   did: 'did:plc:testuser123',
@@ -44,6 +44,32 @@ describe('hydratePostView', () => {
     expect(view.likeCount).toBe(0)
     expect(view.quoteCount).toBe(0)
     expect(view.indexedAt).toBe('2026-04-10T12:00:00.000Z')
+  })
+
+  it('uses provided interaction counts', () => {
+    const record = {
+      $type: 'app.bsky.feed.post',
+      text: 'Hello world',
+      createdAt: '2026-04-10T12:00:00.000Z',
+    }
+    const counts: PostInteractionCounts = {
+      likeCount: 42,
+      repostCount: 7,
+      replyCount: 13,
+      quoteCount: 3,
+    }
+    const view = hydratePostView(
+      record,
+      BASE_URI,
+      BASE_CID,
+      MOCK_MINIDOC,
+      counts,
+    )
+
+    expect(view.likeCount).toBe(42)
+    expect(view.repostCount).toBe(7)
+    expect(view.replyCount).toBe(13)
+    expect(view.quoteCount).toBe(3)
   })
 
   it('uses current time as indexedAt when createdAt missing', () => {
@@ -228,6 +254,32 @@ describe('hydratePostViewRecord', () => {
     expect(vr.embeds![0].$type).toBe('app.bsky.embed.images#view')
     expect(vr.replyCount).toBe(0)
     expect(vr.likeCount).toBe(0)
+  })
+
+  it('uses provided interaction counts', () => {
+    const record = {
+      $type: 'app.bsky.feed.post',
+      text: 'test',
+      createdAt: '2026-04-10T12:00:00.000Z',
+    }
+    const counts: PostInteractionCounts = {
+      likeCount: 99,
+      repostCount: 15,
+      replyCount: 8,
+      quoteCount: 2,
+    }
+    const vr = hydratePostViewRecord(
+      record,
+      'at://did:plc:testuser123/app.bsky.feed.post/3abc',
+      'bafyrei123',
+      MOCK_MINIDOC,
+      counts,
+    )
+
+    expect(vr.likeCount).toBe(99)
+    expect(vr.repostCount).toBe(15)
+    expect(vr.replyCount).toBe(8)
+    expect(vr.quoteCount).toBe(2)
   })
 
   it('returns undefined embeds when no embed in record', () => {

--- a/src/lib/slingshot/blobs.ts
+++ b/src/lib/slingshot/blobs.ts
@@ -1,0 +1,7 @@
+export function buildPdsBlobUrl(
+  pdsUrl: string,
+  did: string,
+  cid: string,
+): string {
+  return `${pdsUrl}/xrpc/com.atproto.sync.getBlob?did=${encodeURIComponent(did)}&cid=${encodeURIComponent(cid)}`
+}

--- a/src/lib/slingshot/client.ts
+++ b/src/lib/slingshot/client.ts
@@ -1,0 +1,71 @@
+import {type SlingshotMiniDoc, type SlingshotRecord} from './types'
+
+export const SLINGSHOT_SERVICE = 'https://slingshot.microcosm.blue'
+
+const TIMEOUT_MS = 5_000
+const MAX_CONCURRENT = 5
+
+// Simple semaphore for concurrency limiting
+let active = 0
+const waiting: Array<() => void> = []
+
+function acquire(): Promise<void> {
+  if (active < MAX_CONCURRENT) {
+    active++
+    return Promise.resolve()
+  }
+  return new Promise(resolve => {
+    waiting.push(resolve)
+  })
+}
+
+function release() {
+  active--
+  const next = waiting.shift()
+  if (next) {
+    active++
+    next()
+  }
+}
+
+async function slingshotFetch(url: string): Promise<Response> {
+  await acquire()
+  try {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
+    try {
+      const res = await fetch(url, {signal: controller.signal})
+      return res
+    } finally {
+      clearTimeout(timeout)
+    }
+  } finally {
+    release()
+  }
+}
+
+export async function getRecordByUri(
+  atUri: string,
+): Promise<SlingshotRecord | undefined> {
+  try {
+    const url = `${SLINGSHOT_SERVICE}/xrpc/blue.microcosm.repo.getRecordByUri?at_uri=${encodeURIComponent(atUri)}`
+    const res = await slingshotFetch(url)
+    if (!res.ok) return undefined
+    return (await res.json()) as SlingshotRecord
+  } catch {
+    return undefined
+  }
+}
+
+export async function resolveMiniDoc(
+  identifier: string,
+): Promise<SlingshotMiniDoc | undefined> {
+  try {
+    const url = `${SLINGSHOT_SERVICE}/xrpc/blue.microcosm.identity.resolveMiniDoc?identifier=${encodeURIComponent(identifier)}`
+    const res = await slingshotFetch(url)
+    if (!res.ok) return undefined
+    return (await res.json()) as SlingshotMiniDoc
+  } catch {
+    return undefined
+  }
+}

--- a/src/lib/slingshot/constellation.ts
+++ b/src/lib/slingshot/constellation.ts
@@ -1,0 +1,53 @@
+import {type PostInteractionCounts} from './types'
+
+export const CONSTELLATION_SERVICE = 'https://constellation.microcosm.blue'
+
+const TIMEOUT_MS = 5_000
+
+async function constellationFetch(url: string): Promise<Response> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
+  try {
+    return await fetch(url, {
+      signal: controller.signal,
+      headers: {Accept: 'application/json'},
+    })
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+/**
+ * Fetch the count of backlinks for a given subject and source type.
+ * Returns 0 on any error.
+ */
+async function getBacklinksCount(
+  subject: string,
+  source: string,
+): Promise<number> {
+  try {
+    const url = `${CONSTELLATION_SERVICE}/xrpc/blue.microcosm.links.getBacklinksCount?subject=${encodeURIComponent(subject)}&source=${encodeURIComponent(source)}`
+    const res = await constellationFetch(url)
+    if (!res.ok) return 0
+    const data = (await res.json()) as {count?: number}
+    return data.count ?? 0
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * Fetch like, repost, reply, and quote counts for a post from Constellation.
+ * All four requests are made in parallel. Returns 0 for any that fail.
+ */
+export async function getPostInteractionCounts(
+  postUri: string,
+): Promise<PostInteractionCounts> {
+  const [likeCount, repostCount, replyCount, quoteCount] = await Promise.all([
+    getBacklinksCount(postUri, 'app.bsky.feed.like:subject.uri'),
+    getBacklinksCount(postUri, 'app.bsky.feed.repost:subject.uri'),
+    getBacklinksCount(postUri, 'app.bsky.feed.post:reply.parent.uri'),
+    getBacklinksCount(postUri, 'app.bsky.feed.post:embed.record.uri'),
+  ])
+  return {likeCount, repostCount, replyCount, quoteCount}
+}

--- a/src/lib/slingshot/hydrate.ts
+++ b/src/lib/slingshot/hydrate.ts
@@ -10,7 +10,7 @@ import {
 } from '@atproto/api'
 
 import {buildPdsBlobUrl} from './blobs'
-import {type SlingshotMiniDoc} from './types'
+import {type PostInteractionCounts, type SlingshotMiniDoc} from './types'
 
 type BlobRef = {
   $type?: 'blob'
@@ -159,6 +159,7 @@ export function hydratePostView(
   uri: string,
   cid: string,
   miniDoc: SlingshotMiniDoc,
+  counts?: PostInteractionCounts,
 ): AppBskyFeedDefs.PostView {
   const author: AppBskyActorDefs.ProfileViewBasic = {
     $type: 'app.bsky.actor.defs#profileViewBasic',
@@ -178,10 +179,10 @@ export function hydratePostView(
     author,
     record,
     embed,
-    replyCount: 0,
-    repostCount: 0,
-    likeCount: 0,
-    quoteCount: 0,
+    replyCount: counts?.replyCount ?? 0,
+    repostCount: counts?.repostCount ?? 0,
+    likeCount: counts?.likeCount ?? 0,
+    quoteCount: counts?.quoteCount ?? 0,
     indexedAt:
       typeof record.createdAt === 'string'
         ? record.createdAt
@@ -194,6 +195,7 @@ export function hydratePostViewRecord(
   uri: string,
   cid: string,
   miniDoc: SlingshotMiniDoc,
+  counts?: PostInteractionCounts,
 ): $Typed<AppBskyEmbedRecord.ViewRecord> {
   const author: AppBskyActorDefs.ProfileViewBasic = {
     $type: 'app.bsky.actor.defs#profileViewBasic',
@@ -213,10 +215,10 @@ export function hydratePostViewRecord(
     author,
     value: record,
     embeds: embed ? [embed] : undefined,
-    replyCount: 0,
-    repostCount: 0,
-    likeCount: 0,
-    quoteCount: 0,
+    replyCount: counts?.replyCount ?? 0,
+    repostCount: counts?.repostCount ?? 0,
+    likeCount: counts?.likeCount ?? 0,
+    quoteCount: counts?.quoteCount ?? 0,
     indexedAt:
       typeof record.createdAt === 'string'
         ? record.createdAt

--- a/src/lib/slingshot/hydrate.ts
+++ b/src/lib/slingshot/hydrate.ts
@@ -1,0 +1,238 @@
+import {
+  type $Typed,
+  type AppBskyActorDefs,
+  type AppBskyEmbedExternal,
+  type AppBskyEmbedImages,
+  type AppBskyEmbedRecord,
+  type AppBskyEmbedRecordWithMedia,
+  type AppBskyFeedDefs,
+  AppBskyFeedPost,
+} from '@atproto/api'
+
+import {buildPdsBlobUrl} from './blobs'
+import {type SlingshotMiniDoc} from './types'
+
+type BlobRef = {
+  $type?: 'blob'
+  ref: {$link: string}
+  mimeType: string
+  size: number
+}
+
+function isBlobRef(v: unknown): v is BlobRef {
+  if (typeof v !== 'object' || v == null) return false
+  const obj = v as Record<string, unknown>
+  const ref = obj.ref
+  return (
+    typeof ref === 'object' &&
+    ref != null &&
+    typeof (ref as Record<string, unknown>).$link === 'string'
+  )
+}
+
+function hydrateImagesEmbed(
+  embed: Record<string, unknown>,
+  pdsUrl: string,
+  did: string,
+): $Typed<AppBskyEmbedImages.View> | undefined {
+  const images = embed.images
+  if (!Array.isArray(images)) return undefined
+
+  const viewImages: AppBskyEmbedImages.ViewImage[] = []
+  for (const img of images) {
+    if (typeof img !== 'object' || img == null) continue
+    const blob = img.image
+    if (!isBlobRef(blob)) continue
+    const url = buildPdsBlobUrl(pdsUrl, did, blob.ref.$link)
+    viewImages.push({
+      $type: 'app.bsky.embed.images#viewImage',
+      thumb: url,
+      fullsize: url,
+      alt: typeof img.alt === 'string' ? img.alt : '',
+      aspectRatio: img.aspectRatio as
+        | {width: number; height: number}
+        | undefined,
+    })
+  }
+  if (viewImages.length === 0) return undefined
+
+  return {
+    $type: 'app.bsky.embed.images#view',
+    images: viewImages,
+  }
+}
+
+function hydrateExternalEmbed(
+  embed: Record<string, unknown>,
+  pdsUrl: string,
+  did: string,
+): $Typed<AppBskyEmbedExternal.View> | undefined {
+  const ext = embed.external
+  if (typeof ext !== 'object' || ext == null) return undefined
+  const e = ext as Record<string, unknown>
+
+  let thumb: string | undefined
+  if (isBlobRef(e.thumb)) {
+    thumb = buildPdsBlobUrl(pdsUrl, did, e.thumb.ref.$link)
+  }
+
+  return {
+    $type: 'app.bsky.embed.external#view',
+    external: {
+      $type: 'app.bsky.embed.external#viewExternal',
+      uri: typeof e.uri === 'string' ? e.uri : '',
+      title: typeof e.title === 'string' ? e.title : '',
+      description: typeof e.description === 'string' ? e.description : '',
+      thumb,
+    },
+  }
+}
+
+function hydrateRecordEmbed(
+  embed: Record<string, unknown>,
+): $Typed<AppBskyEmbedRecord.View> | undefined {
+  const record = embed.record
+  if (typeof record !== 'object' || record == null) return undefined
+  const r = record as Record<string, unknown>
+  const uri = r.uri
+  if (typeof uri !== 'string') return undefined
+
+  // We can't hydrate the referenced record from Slingshot recursively here,
+  // so return it as viewNotFound and let the UI trigger its own fallback.
+  return {
+    $type: 'app.bsky.embed.record#view',
+    record: {
+      $type: 'app.bsky.embed.record#viewNotFound',
+      uri,
+      notFound: true,
+    },
+  }
+}
+
+function hydrateEmbed(
+  rawEmbed: Record<string, unknown>,
+  pdsUrl: string,
+  did: string,
+):
+  | $Typed<AppBskyEmbedImages.View>
+  | $Typed<AppBskyEmbedExternal.View>
+  | $Typed<AppBskyEmbedRecord.View>
+  | $Typed<AppBskyEmbedRecordWithMedia.View>
+  | undefined {
+  const type = rawEmbed.$type
+
+  if (type === 'app.bsky.embed.images') {
+    return hydrateImagesEmbed(rawEmbed, pdsUrl, did)
+  }
+  if (type === 'app.bsky.embed.external') {
+    return hydrateExternalEmbed(rawEmbed, pdsUrl, did)
+  }
+  if (type === 'app.bsky.embed.record') {
+    return hydrateRecordEmbed(rawEmbed)
+  }
+  if (type === 'app.bsky.embed.recordWithMedia') {
+    const recordPart = rawEmbed.record as Record<string, unknown> | undefined
+    const mediaPart = rawEmbed.media as Record<string, unknown> | undefined
+
+    const hydratedRecord = recordPart
+      ? hydrateRecordEmbed(recordPart)
+      : undefined
+    const hydratedMedia = mediaPart
+      ? (hydrateImagesEmbed(mediaPart, pdsUrl, did) ??
+        hydrateExternalEmbed(mediaPart, pdsUrl, did))
+      : undefined
+
+    if (!hydratedRecord || !hydratedMedia) return undefined
+
+    return {
+      $type: 'app.bsky.embed.recordWithMedia#view',
+      record: hydratedRecord,
+      media: hydratedMedia,
+    }
+  }
+  // Video embeds cannot be hydrated (need HLS playlist URL from transcoding service)
+  return undefined
+}
+
+export function hydratePostView(
+  record: Record<string, unknown>,
+  uri: string,
+  cid: string,
+  miniDoc: SlingshotMiniDoc,
+): AppBskyFeedDefs.PostView {
+  const author: AppBskyActorDefs.ProfileViewBasic = {
+    $type: 'app.bsky.actor.defs#profileViewBasic',
+    did: miniDoc.did,
+    handle: miniDoc.handle,
+  }
+
+  const rawEmbed = record.embed as Record<string, unknown> | undefined
+  const embed = rawEmbed
+    ? hydrateEmbed(rawEmbed, miniDoc.pds, miniDoc.did)
+    : undefined
+
+  return {
+    $type: 'app.bsky.feed.defs#postView',
+    uri,
+    cid,
+    author,
+    record,
+    embed,
+    replyCount: 0,
+    repostCount: 0,
+    likeCount: 0,
+    quoteCount: 0,
+    indexedAt:
+      typeof record.createdAt === 'string'
+        ? record.createdAt
+        : new Date().toISOString(),
+  }
+}
+
+export function hydratePostViewRecord(
+  record: Record<string, unknown>,
+  uri: string,
+  cid: string,
+  miniDoc: SlingshotMiniDoc,
+): $Typed<AppBskyEmbedRecord.ViewRecord> {
+  const author: AppBskyActorDefs.ProfileViewBasic = {
+    $type: 'app.bsky.actor.defs#profileViewBasic',
+    did: miniDoc.did,
+    handle: miniDoc.handle,
+  }
+
+  const rawEmbed = record.embed as Record<string, unknown> | undefined
+  const embed = rawEmbed
+    ? hydrateEmbed(rawEmbed, miniDoc.pds, miniDoc.did)
+    : undefined
+
+  return {
+    $type: 'app.bsky.embed.record#viewRecord',
+    uri,
+    cid,
+    author,
+    value: record,
+    embeds: embed ? [embed] : undefined,
+    replyCount: 0,
+    repostCount: 0,
+    likeCount: 0,
+    quoteCount: 0,
+    indexedAt:
+      typeof record.createdAt === 'string'
+        ? record.createdAt
+        : new Date().toISOString(),
+  }
+}
+
+export function hydrateAvatarUrl(
+  record: Record<string, unknown>,
+  miniDoc: SlingshotMiniDoc,
+): string | undefined {
+  if (!AppBskyFeedPost.isRecord(record)) {
+    // This is a profile record, not a post
+    const avatar = record.avatar
+    if (!isBlobRef(avatar)) return undefined
+    return buildPdsBlobUrl(miniDoc.pds, miniDoc.did, avatar.ref.$link)
+  }
+  return undefined
+}

--- a/src/lib/slingshot/types.ts
+++ b/src/lib/slingshot/types.ts
@@ -1,0 +1,18 @@
+/**
+ * Response from blue.microcosm.repo.getRecordByUri
+ */
+export type SlingshotRecord = {
+  uri: string
+  cid?: string
+  value: Record<string, unknown>
+}
+
+/**
+ * Response from blue.microcosm.identity.resolveMiniDoc
+ */
+export type SlingshotMiniDoc = {
+  did: string
+  handle: string
+  pds: string
+  signing_key: string
+}

--- a/src/lib/slingshot/types.ts
+++ b/src/lib/slingshot/types.ts
@@ -16,3 +16,13 @@ export type SlingshotMiniDoc = {
   pds: string
   signing_key: string
 }
+
+/**
+ * Interaction counts for a post, fetched from Constellation backlinks.
+ */
+export type PostInteractionCounts = {
+  likeCount: number
+  repostCount: number
+  replyCount: number
+  quoteCount: number
+}

--- a/src/state/queries/__tests__/slingshot.test.ts
+++ b/src/state/queries/__tests__/slingshot.test.ts
@@ -1,0 +1,59 @@
+import {TID} from '@atproto/common-web'
+
+import {_rkeyFromUri as rkeyFromUri, isRecentTid} from '../slingshot'
+
+describe('isRecentTid', () => {
+  it('returns true for a TID created just now', () => {
+    const tid = TID.next()
+    expect(isRecentTid(tid.toString())).toBe(true)
+  })
+
+  it('returns false for an invalid TID', () => {
+    expect(isRecentTid('not-a-tid')).toBe(false)
+    expect(isRecentTid('')).toBe(false)
+  })
+
+  it('returns false for a very old TID', () => {
+    // Create a TID from a timestamp 30 days ago
+    const thirtyDaysAgoUs = (Date.now() - 30 * 24 * 60 * 60 * 1000) * 1000
+    const tid = TID.fromTime(thirtyDaysAgoUs, 0)
+    expect(isRecentTid(tid.toString())).toBe(false)
+  })
+
+  it('returns true for a TID from 3 days ago', () => {
+    const threeDaysAgoUs = (Date.now() - 3 * 24 * 60 * 60 * 1000) * 1000
+    const tid = TID.fromTime(threeDaysAgoUs, 0)
+    expect(isRecentTid(tid.toString())).toBe(true)
+  })
+
+  it('returns false for a TID from 8 days ago', () => {
+    const eightDaysAgoUs = (Date.now() - 8 * 24 * 60 * 60 * 1000) * 1000
+    const tid = TID.fromTime(eightDaysAgoUs, 0)
+    expect(isRecentTid(tid.toString())).toBe(false)
+  })
+})
+
+describe('rkeyFromUri', () => {
+  it('extracts rkey from a standard at-uri', () => {
+    expect(rkeyFromUri('at://did:plc:abc123/app.bsky.feed.post/3abcxyz')).toBe(
+      '3abcxyz',
+    )
+  })
+
+  it('returns undefined for too-short URIs', () => {
+    expect(rkeyFromUri('at://did:plc:abc123')).toBeUndefined()
+    expect(
+      rkeyFromUri('at://did:plc:abc123/app.bsky.feed.post'),
+    ).toBeUndefined()
+  })
+
+  it('handles URIs with extra segments', () => {
+    expect(rkeyFromUri('at://did:plc:abc/app.bsky.feed.post/3abc/extra')).toBe(
+      '3abc',
+    )
+  })
+
+  it('returns undefined for empty string', () => {
+    expect(rkeyFromUri('')).toBeUndefined()
+  })
+})

--- a/src/state/queries/slingshot.ts
+++ b/src/state/queries/slingshot.ts
@@ -3,6 +3,7 @@ import {TID} from '@atproto/common-web'
 import {useQuery} from '@tanstack/react-query'
 
 import {getRecordByUri, resolveMiniDoc} from '#/lib/slingshot/client'
+import {getPostInteractionCounts} from '#/lib/slingshot/constellation'
 import {hydrateAvatarUrl, hydratePostViewRecord} from '#/lib/slingshot/hydrate'
 import {STALE} from '#/state/queries'
 
@@ -51,9 +52,10 @@ export function useSlingshotRecordQuery({
       const didMatch = atUri.match(/^at:\/\/(did:[^/]+)/)
       if (!didMatch) return undefined
 
-      const [record, miniDoc] = await Promise.all([
+      const [record, miniDoc, counts] = await Promise.all([
         getRecordByUri(atUri),
         resolveMiniDoc(didMatch[1]),
+        getPostInteractionCounts(atUri),
       ])
 
       if (!record || !miniDoc) return undefined
@@ -63,6 +65,7 @@ export function useSlingshotRecordQuery({
         record.uri,
         record.cid ?? '',
         miniDoc,
+        counts,
       )
     },
     staleTime: STALE.MINUTES.FIVE,

--- a/src/state/queries/slingshot.ts
+++ b/src/state/queries/slingshot.ts
@@ -1,0 +1,102 @@
+import {type AppBskyEmbedRecord} from '@atproto/api'
+import {TID} from '@atproto/common-web'
+import {useQuery} from '@tanstack/react-query'
+
+import {getRecordByUri, resolveMiniDoc} from '#/lib/slingshot/client'
+import {hydrateAvatarUrl, hydratePostViewRecord} from '#/lib/slingshot/hydrate'
+import {STALE} from '#/state/queries'
+
+const THIRTY_DAYS = 30 * 24 * 60 * 60 * 1000
+const SEVEN_DAYS_US = 7 * 24 * 60 * 60 * 1_000_000 // microseconds
+
+/**
+ * Check if a TID rkey is recent enough to warrant a Slingshot lookup.
+ * TIDs encode timestamps in microseconds. Posts older than 7 days
+ * are likely genuinely deleted rather than just unindexed.
+ */
+export function isRecentTid(rkey: string): boolean {
+  try {
+    const tid = TID.fromStr(rkey)
+    const nowUs = Date.now() * 1000
+    return nowUs - tid.timestamp() < SEVEN_DAYS_US
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Extract the rkey from an at-uri.
+ * at://did:plc:xxx/app.bsky.feed.post/3abc123 → "3abc123"
+ */
+function rkeyFromUri(atUri: string): string | undefined {
+  const parts = atUri.split('/')
+  return parts.length >= 5 ? parts[4] : undefined
+}
+
+/**
+ * Fetch a record from Slingshot and return it as a hydrated ViewRecord
+ * (suitable for rendering as a quoted post embed).
+ */
+export function useSlingshotRecordQuery({
+  atUri,
+  enabled = false,
+}: {
+  atUri: string
+  enabled?: boolean
+}) {
+  return useQuery<AppBskyEmbedRecord.ViewRecord | undefined>({
+    queryKey: ['slingshot-record', atUri],
+    queryFn: async () => {
+      // Extract DID from at-uri for identity resolution
+      const didMatch = atUri.match(/^at:\/\/(did:[^/]+)/)
+      if (!didMatch) return undefined
+
+      const [record, miniDoc] = await Promise.all([
+        getRecordByUri(atUri),
+        resolveMiniDoc(didMatch[1]),
+      ])
+
+      if (!record || !miniDoc) return undefined
+
+      return hydratePostViewRecord(
+        record.value,
+        record.uri,
+        record.cid ?? '',
+        miniDoc,
+      )
+    },
+    staleTime: STALE.MINUTES.FIVE,
+    enabled,
+  })
+}
+
+/**
+ * Fetch a profile's avatar from Slingshot when the appview hasn't indexed it.
+ * Returns a PDS-direct blob URL for the avatar.
+ */
+export function useSlingshotAvatarQuery({
+  did,
+  enabled = false,
+}: {
+  did: string
+  enabled?: boolean
+}) {
+  return useQuery<string | undefined>({
+    queryKey: ['slingshot-avatar', did],
+    queryFn: async () => {
+      const profileUri = `at://${did}/app.bsky.actor.profile/self`
+      const [record, miniDoc] = await Promise.all([
+        getRecordByUri(profileUri),
+        resolveMiniDoc(did),
+      ])
+
+      if (!record || !miniDoc) return undefined
+      return hydrateAvatarUrl(record.value, miniDoc)
+    },
+    staleTime: THIRTY_DAYS,
+    gcTime: THIRTY_DAYS,
+    enabled,
+  })
+}
+
+export {isRecentTid as _isRecentTid, rkeyFromUri as _rkeyFromUri}

--- a/src/view/com/util/UserAvatar.tsx
+++ b/src/view/com/util/UserAvatar.tsx
@@ -35,6 +35,7 @@ import {
   compressImage,
   createComposerImage,
 } from '#/state/gallery'
+import {useSlingshotAvatarQuery} from '#/state/queries/slingshot'
 import {unstableCacheProfileView} from '#/state/queries/unstable-profile-cache'
 import {EditImageDialog} from '#/view/com/composer/photos/EditImageDialog'
 import {atoms as a, tokens, useTheme} from '#/alf'
@@ -71,6 +72,7 @@ interface BaseUserAvatarProps {
 
 interface UserAvatarProps extends BaseUserAvatarProps {
   type: UserAvatarType
+  did?: string
   moderation?: ModerationUI
   usePlainRNImage?: boolean
   noBorder?: boolean
@@ -216,7 +218,8 @@ let UserAvatar = ({
   type = 'user',
   shape: overrideShape,
   size,
-  avatar,
+  avatar: avatarProp,
+  did,
   moderation,
   usePlainRNImage = false,
   onLoad,
@@ -226,6 +229,11 @@ let UserAvatar = ({
   noBorder,
 }: UserAvatarProps): React.ReactNode => {
   const t = useTheme()
+  const {data: slingshotAvatar} = useSlingshotAvatarQuery({
+    did: did ?? '',
+    enabled: !avatarProp && !!did,
+  })
+  const avatar = avatarProp || slingshotAvatar || undefined
   const finalShape = overrideShape ?? (type === 'user' ? 'circle' : 'square')
 
   const aviStyle = useMemo(() => {
@@ -554,6 +562,7 @@ let PreviewableUserAvatar = ({
   const avatarEl = (
     <UserAvatar
       avatar={profile.avatar}
+      did={profile.did}
       moderation={moderation}
       type={profile.associated?.labeler ? 'labeler' : 'user'}
       live={status.isActive || live}


### PR DESCRIPTION
When the appview hasn't indexed content from the wider AT Protocol network, fall back to Slingshot to fetch raw records directly. This covers missing quoted posts and missing profile avatars.

What it does
* Missing quoted posts: When a quote embed returns post_not_found, attempts to fetch the record from Slingshot and render it normally. Uses a 7-day recency heuristic on the TID rkey to skip genuinely deleted posts.
* Missing avatars: When UserAvatar has no avatar URL but has a DID, fetches the profile record from Slingshot and constructs a PDS-direct blob URL.
* All Slingshot requests fail silently — if Slingshot is down or the record truly doesn't exist, the existing "Deleted" placeholder or default avatar renders as before.