### PR TITLE
Feat/appview routing

### DIFF
--- a/bskyembed/src/screens/landing.tsx
+++ b/bskyembed/src/screens/landing.tsx
@@ -25,7 +25,7 @@ if (!root) throw new Error('No root element')
 initSystemColorMode({additionalBodyClasses: 'dark:bg-dimmedBgDarken'})
 
 const agent = new AtpAgent({
-  service: AppSettings.PUBLIC_BSKY_SERVICE,
+  service: AppSettings.DEFAULT_BSKY_SERVICE,
 })
 
 const baseHostname = new URL(AppSettings.BASE_URL).hostname

--- a/bskyembed/src/screens/post.tsx
+++ b/bskyembed/src/screens/post.tsx
@@ -16,7 +16,7 @@ const root = document.getElementById('app')
 if (!root) throw new Error('No root element')
 
 const agent = new AtpAgent({
-  service: AppSettings.PUBLIC_BSKY_SERVICE,
+  service: AppSettings.DEFAULT_BSKY_SERVICE,
 })
 
 const uri = `at://${window.location.pathname.slice('/embed/'.length)}`

--- a/src/ageAssurance/data.tsx
+++ b/src/ageAssurance/data.tsx
@@ -12,7 +12,7 @@ import {persistQueryClient} from '@tanstack/react-query-persist-client'
 import debounce from 'lodash.debounce'
 
 import {networkRetry} from '#/lib/async/retry'
-import {PUBLIC_BSKY_SERVICE} from '#/lib/constants'
+import {DEFAULT_BSKY_SERVICE} from '#/lib/constants'
 import {createPersistedQueryStorage} from '#/lib/persisted-query-storage'
 import {getAge} from '#/lib/strings/time'
 import {
@@ -92,7 +92,7 @@ export const configQueryKey = ['config']
 export async function getConfig() {
   if (debug.enabled) return debug.resolve(debug.config)
   const agent = new AtpAgent({
-    service: PUBLIC_BSKY_SERVICE,
+    service: DEFAULT_BSKY_SERVICE,
   })
   const res = await agent.app.bsky.ageassurance.getConfig()
   return res.data

--- a/src/ageAssurance/useBeginAgeAssurance.ts
+++ b/src/ageAssurance/useBeginAgeAssurance.ts
@@ -11,6 +11,9 @@ import {logger} from '#/ageAssurance/logger'
 import {useAnalytics} from '#/analytics'
 import {BLUESKY_PROXY_DID} from '#/env'
 import {useGeolocation} from '#/geolocation'
+import {AppSettings} from '#/indie-settings/settings'
+
+const IS_DEV_ENV = BLUESKY_PROXY_DID !== AppSettings.DEFAULT_BSKY_SERVICE_DID
 
 export function useBeginAgeAssurance() {
   const ax = useAnalytics()
@@ -19,11 +22,7 @@ export function useBeginAgeAssurance() {
   const geolocation = useGeolocation()
   const patchAgeAssuranceStateResponse = usePatchAgeAssuranceServerState()
 
-  // Dev env is detected when the runtime proxy DID differs from the appview
-  // DID that was resolved for this session (e.g. tests override via
-  // `BLUESKY_PROXY_DID`).
-  const isDevEnv = BLUESKY_PROXY_DID !== appview.BSKY_SERVICE_DID
-  const appviewUrl = isDevEnv ? DEV_ENV_APPVIEW : appview.BSKY_SERVICE
+  const appviewUrl = IS_DEV_ENV ? DEV_ENV_APPVIEW : appview.BSKY_SERVICE
 
   return useMutation({
     async mutationFn(

--- a/src/ageAssurance/useBeginAgeAssurance.ts
+++ b/src/ageAssurance/useBeginAgeAssurance.ts
@@ -3,27 +3,27 @@ import {type AppBskyAgeassuranceBegin, AtpAgent} from '@atproto/api'
 import {useMutation} from '@tanstack/react-query'
 
 import {wait} from '#/lib/async/wait'
-import {
-  DEV_ENV_APPVIEW,
-  PUBLIC_APPVIEW,
-  PUBLIC_APPVIEW_DID,
-} from '#/lib/constants'
+import {DEV_ENV_APPVIEW} from '#/lib/constants'
 import {isNetworkError} from '#/lib/hooks/useCleanError'
-import {useAgent} from '#/state/session'
+import {useAgent, useAppview} from '#/state/session'
 import {usePatchAgeAssuranceServerState} from '#/ageAssurance'
 import {logger} from '#/ageAssurance/logger'
 import {useAnalytics} from '#/analytics'
 import {BLUESKY_PROXY_DID} from '#/env'
 import {useGeolocation} from '#/geolocation'
 
-const IS_DEV_ENV = BLUESKY_PROXY_DID !== PUBLIC_APPVIEW_DID
-const APPVIEW = IS_DEV_ENV ? DEV_ENV_APPVIEW : PUBLIC_APPVIEW
-
 export function useBeginAgeAssurance() {
   const ax = useAnalytics()
   const agent = useAgent()
+  const appview = useAppview()
   const geolocation = useGeolocation()
   const patchAgeAssuranceStateResponse = usePatchAgeAssuranceServerState()
+
+  // Dev env is detected when the runtime proxy DID differs from the appview
+  // DID that was resolved for this session (e.g. tests override via
+  // `BLUESKY_PROXY_DID`).
+  const isDevEnv = BLUESKY_PROXY_DID !== appview.BSKY_SERVICE_DID
+  const appviewUrl = isDevEnv ? DEV_ENV_APPVIEW : appview.BSKY_SERVICE
 
   return useMutation({
     async mutationFn(
@@ -45,7 +45,7 @@ export function useBeginAgeAssurance() {
         lxm: `app.bsky.ageassurance.begin`,
       })
 
-      const appView = new AtpAgent({service: APPVIEW})
+      const appView = new AtpAgent({service: appviewUrl})
       appView.sessionManager.session = {...agent.session!}
       appView.sessionManager.session.accessJwt = token
       appView.sessionManager.session.refreshJwt = ''

--- a/src/env/common.ts
+++ b/src/env/common.ts
@@ -78,7 +78,7 @@ export const LOG_DEBUG: string = process.env.EXPO_PUBLIC_LOG_DEBUG || ''
  */
 export const BLUESKY_PROXY_DID: Did =
   process.env.EXPO_PUBLIC_BLUESKY_PROXY_DID ||
-  (AppSettings.PUBLIC_BSKY_SERVICE_DID as Did)
+  (AppSettings.DEFAULT_BSKY_SERVICE_DID as Did)
 
 /**
  * The DID of the chat service to proxy to

--- a/src/indie-settings/__tests__/settings.test.ts
+++ b/src/indie-settings/__tests__/settings.test.ts
@@ -1,0 +1,102 @@
+import {describe, expect, it} from '@jest/globals'
+
+import {
+  AppSettings,
+  type AppviewRoute,
+  resolveAppviewForPdsHost,
+} from '#/indie-settings/settings'
+
+function withRoutes<T>(routes: AppviewRoute[], fn: () => T): T {
+  const original = AppSettings.APPVIEW_ROUTES
+  AppSettings.APPVIEW_ROUTES = routes
+  try {
+    return fn()
+  } finally {
+    AppSettings.APPVIEW_ROUTES = original
+  }
+}
+
+describe('resolveAppviewForPdsHost', () => {
+  it('falls back to DEFAULT_BSKY_SERVICE when no routes are configured', () => {
+    const result = withRoutes([], () =>
+      resolveAppviewForPdsHost('pds-one.test'),
+    )
+    expect(result).toEqual({
+      BSKY_SERVICE: AppSettings.DEFAULT_BSKY_SERVICE,
+      BSKY_SERVICE_DID: AppSettings.DEFAULT_BSKY_SERVICE_DID,
+    })
+  })
+
+  it('falls back when pdsHost is undefined', () => {
+    const result = resolveAppviewForPdsHost(undefined)
+    expect(result).toEqual({
+      BSKY_SERVICE: AppSettings.DEFAULT_BSKY_SERVICE,
+      BSKY_SERVICE_DID: AppSettings.DEFAULT_BSKY_SERVICE_DID,
+    })
+  })
+
+  describe('with configured routes', () => {
+    const routes: AppviewRoute[] = [
+      {
+        pdsHosts: ['pds-one.test', 'pds-two.test'],
+        BSKY_SERVICE: 'https://appview-a.test',
+        BSKY_SERVICE_DID: 'did:web:appview-a.test',
+      },
+      {
+        pdsHosts: ['pds-three.test'],
+        BSKY_SERVICE: 'https://appview-b.test',
+        BSKY_SERVICE_DID: 'did:web:appview-b.test',
+      },
+    ]
+
+    it('matches the first PDS host in a route', () => {
+      const result = withRoutes(routes, () =>
+        resolveAppviewForPdsHost('pds-one.test'),
+      )
+      expect(result).toEqual({
+        BSKY_SERVICE: 'https://appview-a.test',
+        BSKY_SERVICE_DID: 'did:web:appview-a.test',
+      })
+    })
+
+    it('matches additional PDS hosts in the same route', () => {
+      const result = withRoutes(routes, () =>
+        resolveAppviewForPdsHost('pds-two.test'),
+      )
+      expect(result).toEqual({
+        BSKY_SERVICE: 'https://appview-a.test',
+        BSKY_SERVICE_DID: 'did:web:appview-a.test',
+      })
+    })
+
+    it('matches case-insensitively', () => {
+      const result = withRoutes(routes, () =>
+        resolveAppviewForPdsHost('PDS-One.Test'),
+      )
+      expect(result).toEqual({
+        BSKY_SERVICE: 'https://appview-a.test',
+        BSKY_SERVICE_DID: 'did:web:appview-a.test',
+      })
+    })
+
+    it('returns the matching route for other hosts', () => {
+      const result = withRoutes(routes, () =>
+        resolveAppviewForPdsHost('pds-three.test'),
+      )
+      expect(result).toEqual({
+        BSKY_SERVICE: 'https://appview-b.test',
+        BSKY_SERVICE_DID: 'did:web:appview-b.test',
+      })
+    })
+
+    it('falls back when no route matches', () => {
+      const result = withRoutes(routes, () =>
+        resolveAppviewForPdsHost('unknown.test'),
+      )
+      expect(result).toEqual({
+        BSKY_SERVICE: AppSettings.DEFAULT_BSKY_SERVICE,
+        BSKY_SERVICE_DID: AppSettings.DEFAULT_BSKY_SERVICE_DID,
+      })
+    })
+  })
+})

--- a/src/indie-settings/northsky.settings.example.ts
+++ b/src/indie-settings/northsky.settings.example.ts
@@ -32,8 +32,10 @@ export const NorthSkyAppSettings: Partial<IndieAppSettings> = {
   HELP_DESK_LANG,
   HELP_DESK_URL: `https://blueskyweb.zendesk.com/hc/${HELP_DESK_LANG}`,
   LOGO_SVG_PATH: 'indie-settings/assets/northsky/SvgLogo',
-  DEFAULT_BSKY_SERVICE: 'https://api.blacksky.community',
-  DEFAULT_BSKY_SERVICE_DID: 'did:web:api.blacksky.community',
+  // Fallback appview for accounts whose PDS host isn't listed in
+  // APPVIEW_ROUTES above (e.g. bsky.social accounts on *.host.bsky.network).
+  DEFAULT_BSKY_SERVICE: 'https://api.bsky.app',
+  DEFAULT_BSKY_SERVICE_DID: 'did:web:api.bsky.app',
   STAGING_SERVICE: 'https://staging.bsky.dev',
   STAGING_DEFAULT_FEED_URI:
     'at://did:plc:23cnpffmuf4vkpsnwhgyvljw/app.bsky.feed.generator/NorthskySocial',

--- a/src/indie-settings/northsky.settings.example.ts
+++ b/src/indie-settings/northsky.settings.example.ts
@@ -8,6 +8,13 @@ export const NorthSkyAppSettings: Partial<IndieAppSettings> = {
   ANALYTICS_ENABLED: false,
   AGE_ASSURANCE_ENABLED: false,
   APP_NAME: 'Northsky',
+  APPVIEW_ROUTES: [
+    {
+      pdsHosts: ['blacksky.community', 'northsky.social'],
+      BSKY_SERVICE: 'https://api.blacksky.community',
+      BSKY_SERVICE_DID: 'did:web:api.blacksky.community',
+    },
+  ],
   BASE_URL: 'https://northsky.app',
   BSKY_DOWNLOAD_URL: 'https://northsky.app/download',
   BSKY_SERVICE: 'https://northsky.social',
@@ -25,8 +32,8 @@ export const NorthSkyAppSettings: Partial<IndieAppSettings> = {
   HELP_DESK_LANG,
   HELP_DESK_URL: `https://blueskyweb.zendesk.com/hc/${HELP_DESK_LANG}`,
   LOGO_SVG_PATH: 'indie-settings/assets/northsky/SvgLogo',
-  PUBLIC_BSKY_SERVICE: 'https://api.blacksky.community',
-  PUBLIC_BSKY_SERVICE_DID: 'did:web:api.blacksky.community',
+  DEFAULT_BSKY_SERVICE: 'https://api.blacksky.community',
+  DEFAULT_BSKY_SERVICE_DID: 'did:web:api.blacksky.community',
   STAGING_SERVICE: 'https://staging.bsky.dev',
   STAGING_DEFAULT_FEED_URI:
     'at://did:plc:23cnpffmuf4vkpsnwhgyvljw/app.bsky.feed.generator/NorthskySocial',

--- a/src/indie-settings/settings.ts
+++ b/src/indie-settings/settings.ts
@@ -1,22 +1,26 @@
 import {NorthSkyAppSettings} from './northsky.settings.example'
 
+/** Resolved appview (service URL + DID) for an account or route. */
+export interface Appview {
+  BSKY_SERVICE: string
+  BSKY_SERVICE_DID: string
+}
+
 /**
- * Maps a set of PDS hostnames to the appview that should serve them.
+ * Maps a set of PDS hostnames to the appview that should serve accounts
+ * signed in through them.
  *
- * Matching is done on the hostname of the account's PDS URL at login time.
- * The PDS host is always known and valid by the time the agent is configured
- * (if it weren't, login would have failed).
+ * Matching is done on the hostname of the service URL the user selected as
+ * their hosting provider in the login form (e.g. `bsky.social`), i.e.
+ * `agent.serviceUrl`. For most deployments this is the same host that runs
+ * the PDS for those accounts.
  */
-export interface AppviewRoute {
+export interface AppviewRoute extends Appview {
   /**
-   * Lowercase PDS hostnames this route applies to (e.g. `blacksky.community`).
+   * Lowercase PDS hostnames this route applies to (e.g. `bsky.social`).
    * Match is exact, no wildcards.
    */
   pdsHosts: string[]
-  /** Appview service URL (e.g. `https://api.blacksky.community`). */
-  BSKY_SERVICE: string
-  /** Appview DID (e.g. `did:web:api.blacksky.community`). */
-  BSKY_SERVICE_DID: string
 }
 
 export interface IndieAppSettings {
@@ -91,18 +95,16 @@ export const AppSettings: IndieAppSettings = {
 }
 
 /**
- * Resolve the appview (service URL + DID) to use for an account whose PDS is
- * hosted on `pdsHost`. The first matching entry in
+ * Resolve the appview (service URL + DID) to use for an account whose
+ * hosting provider is at `pdsHost`. The first matching entry in
  * {@link IndieAppSettings.APPVIEW_ROUTES} wins; otherwise falls back to the
- * configured public appview.
+ * configured default appview.
  *
- * @param pdsHost - Hostname of the account's PDS (e.g. `blacksky.community`).
- *   Undefined for guest/public agents.
+ * @param pdsHost - Hostname of the hosting provider selected at login, i.e.
+ *   `new URL(agent.serviceUrl).hostname` (e.g. `northsky.social`). Undefined
+ *   for guest/public agents.
  */
-export function resolveAppviewForPdsHost(pdsHost: string | undefined): {
-  BSKY_SERVICE: string
-  BSKY_SERVICE_DID: string
-} {
+export function resolveAppviewForPdsHost(pdsHost: string | undefined): Appview {
   if (pdsHost) {
     const normalized = pdsHost.toLowerCase()
     for (const route of AppSettings.APPVIEW_ROUTES) {

--- a/src/indie-settings/settings.ts
+++ b/src/indie-settings/settings.ts
@@ -1,11 +1,31 @@
 import {NorthSkyAppSettings} from './northsky.settings.example'
 
+/**
+ * Maps a set of PDS hostnames to the appview that should serve them.
+ *
+ * Matching is done on the hostname of the account's PDS URL at login time.
+ * The PDS host is always known and valid by the time the agent is configured
+ * (if it weren't, login would have failed).
+ */
+export interface AppviewRoute {
+  /**
+   * Lowercase PDS hostnames this route applies to (e.g. `blacksky.community`).
+   * Match is exact, no wildcards.
+   */
+  pdsHosts: string[]
+  /** Appview service URL (e.g. `https://api.blacksky.community`). */
+  BSKY_SERVICE: string
+  /** Appview DID (e.g. `did:web:api.blacksky.community`). */
+  BSKY_SERVICE_DID: string
+}
+
 export interface IndieAppSettings {
   // Feature flags
   ANALYTICS_ENABLED: boolean
   AGE_ASSURANCE_ENABLED: boolean
   // App identity
   APP_NAME: string
+  APPVIEW_ROUTES: AppviewRoute[]
   BASE_URL: string
   BSKY_DOWNLOAD_URL: string
   BSKY_SERVICE: string
@@ -20,8 +40,8 @@ export interface IndieAppSettings {
   HELP_DESK_LANG: string
   HELP_DESK_URL: string
   LOGO_SVG_PATH: string
-  PUBLIC_BSKY_SERVICE: string
-  PUBLIC_BSKY_SERVICE_DID: string
+  DEFAULT_BSKY_SERVICE: string
+  DEFAULT_BSKY_SERVICE_DID: string
   STAGING_SERVICE: string
   STAGING_DEFAULT_FEED_URI: string
   STAGING_VIDEO_FEED_URI: string
@@ -35,6 +55,7 @@ export const BlueSkyAppSettings: IndieAppSettings = {
   ANALYTICS_ENABLED: false,
   AGE_ASSURANCE_ENABLED: true,
   APP_NAME: 'Bluesky',
+  APPVIEW_ROUTES: [],
   BASE_URL: 'https://bsky.app',
   BSKY_DOWNLOAD_URL: 'https://bsky.app/download',
   BSKY_SERVICE: 'https://bsky.social',
@@ -52,8 +73,8 @@ export const BlueSkyAppSettings: IndieAppSettings = {
   HELP_DESK_LANG,
   HELP_DESK_URL: `https://blueskyweb.zendesk.com/hc/${HELP_DESK_LANG}`,
   LOGO_SVG_PATH: 'indie-settings/assets/bluesky/SvgLogo',
-  PUBLIC_BSKY_SERVICE: 'https://api.bsky.app',
-  PUBLIC_BSKY_SERVICE_DID: 'did:web:api.bsky.app',
+  DEFAULT_BSKY_SERVICE: 'https://api.bsky.app',
+  DEFAULT_BSKY_SERVICE_DID: 'did:web:api.bsky.app',
   STAGING_SERVICE: 'https://staging.bsky.dev',
   STAGING_DEFAULT_FEED_URI:
     'at://did:plc:yofh3kx63drvfljkibw5zuxo/app.bsky.feed.generator/whats-hot',
@@ -67,4 +88,34 @@ export const BlueSkyAppSettings: IndieAppSettings = {
 export const AppSettings: IndieAppSettings = {
   ...BlueSkyAppSettings,
   ...NorthSkyAppSettings,
+}
+
+/**
+ * Resolve the appview (service URL + DID) to use for an account whose PDS is
+ * hosted on `pdsHost`. The first matching entry in
+ * {@link IndieAppSettings.APPVIEW_ROUTES} wins; otherwise falls back to the
+ * configured public appview.
+ *
+ * @param pdsHost - Hostname of the account's PDS (e.g. `blacksky.community`).
+ *   Undefined for guest/public agents.
+ */
+export function resolveAppviewForPdsHost(pdsHost: string | undefined): {
+  BSKY_SERVICE: string
+  BSKY_SERVICE_DID: string
+} {
+  if (pdsHost) {
+    const normalized = pdsHost.toLowerCase()
+    for (const route of AppSettings.APPVIEW_ROUTES) {
+      if (route.pdsHosts.some(h => h.toLowerCase() === normalized)) {
+        return {
+          BSKY_SERVICE: route.BSKY_SERVICE,
+          BSKY_SERVICE_DID: route.BSKY_SERVICE_DID,
+        }
+      }
+    }
+  }
+  return {
+    BSKY_SERVICE: AppSettings.DEFAULT_BSKY_SERVICE,
+    BSKY_SERVICE_DID: AppSettings.DEFAULT_BSKY_SERVICE_DID,
+  }
 }

--- a/src/lib/api/feed/custom.ts
+++ b/src/lib/api/feed/custom.ts
@@ -5,7 +5,7 @@ import {
   jsonStringToLex,
 } from '@atproto/api'
 
-import {PUBLIC_BSKY_SERVICE} from '#/lib/constants'
+import {DEFAULT_BSKY_SERVICE} from '#/lib/constants'
 import {
   getAppLanguageAsContentLanguage,
   getContentLanguages,
@@ -121,7 +121,7 @@ async function loggedOutFetch({
 
   // manually construct fetch call so we can add the `lang` cache-busting param
   let res = await fetch(
-    `${PUBLIC_BSKY_SERVICE}/xrpc/app.bsky.feed.getFeed?feed=${feed}${
+    `${DEFAULT_BSKY_SERVICE}/xrpc/app.bsky.feed.getFeed?feed=${feed}${
       cursor ? `&cursor=${cursor}` : ''
     }&limit=${limit}&lang=${contentLangs}`,
     {
@@ -141,7 +141,7 @@ async function loggedOutFetch({
 
   // no data, try again with language headers removed
   res = await fetch(
-    `${PUBLIC_BSKY_SERVICE}/xrpc/app.bsky.feed.getFeed?feed=${feed}${
+    `${DEFAULT_BSKY_SERVICE}/xrpc/app.bsky.feed.getFeed?feed=${feed}${
       cursor ? `&cursor=${cursor}` : ''
     }&limit=${limit}`,
     {method: 'GET', headers: {'Accept-Language': '', ...labelersHeader}},

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -219,9 +219,6 @@ export const DEV_ENV_APPVIEW_DID = `did:plc:dw4kbjf5mn7nhenabiqpkyh3` // always 
 // temp hack for e2e - esb
 export const BLUESKY_PROXY_HEADER = {
   override: undefined as ProxyHeaderValue | undefined,
-  getOverride() {
-    return this.override
-  },
   set(value: string) {
     this.override = value as ProxyHeaderValue
   },

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -10,7 +10,7 @@ export const LOCAL_DEV_SERVICE =
 export const STAGING_SERVICE = AppSettings.STAGING_SERVICE
 export const BSKY_SERVICE = AppSettings.BSKY_SERVICE
 export const BSKY_SERVICE_DID = AppSettings.BSKY_SERVICE_DID
-export const PUBLIC_BSKY_SERVICE = AppSettings.PUBLIC_BSKY_SERVICE
+export const DEFAULT_BSKY_SERVICE = AppSettings.DEFAULT_BSKY_SERVICE
 export const DEFAULT_SERVICE = BSKY_SERVICE
 export const HELP_DESK_URL = AppSettings.HELP_DESK_URL
 export const EMBED_SERVICE = AppSettings.EMBED_SERVICE
@@ -209,8 +209,8 @@ export const urls = {
   },
 }
 
-export const PUBLIC_APPVIEW = AppSettings.PUBLIC_BSKY_SERVICE
-export const PUBLIC_APPVIEW_DID = AppSettings.PUBLIC_BSKY_SERVICE_DID
+export const PUBLIC_APPVIEW = AppSettings.DEFAULT_BSKY_SERVICE
+export const PUBLIC_APPVIEW_DID = AppSettings.DEFAULT_BSKY_SERVICE_DID
 export const PUBLIC_STAGING_APPVIEW_DID = 'did:web:api.staging.bsky.dev'
 
 export const DEV_ENV_APPVIEW = `http://localhost:2584` // always the same
@@ -218,12 +218,12 @@ export const DEV_ENV_APPVIEW_DID = `did:plc:dw4kbjf5mn7nhenabiqpkyh3` // always 
 
 // temp hack for e2e - esb
 export const BLUESKY_PROXY_HEADER = {
-  value: `${BLUESKY_PROXY_DID}#bsky_appview`,
-  get() {
-    return this.value as ProxyHeaderValue
+  override: undefined as ProxyHeaderValue | undefined,
+  getOverride() {
+    return this.override
   },
   set(value: string) {
-    this.value = value
+    this.override = value as ProxyHeaderValue
   },
 }
 

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -7,16 +7,17 @@ import debounce from 'lodash.debounce'
 
 import {
   BLUESKY_NOTIF_SERVICE_HEADERS,
-  PUBLIC_APPVIEW_DID,
   PUBLIC_STAGING_APPVIEW_DID,
 } from '#/lib/constants'
 import {logger as notyLogger} from '#/lib/notifications/util'
 import {isNetworkError} from '#/lib/strings/errors'
 import {type SessionAccount, useAgent, useSession} from '#/state/session'
+import {getAppviewForAgent} from '#/state/session/agent'
 import BackgroundNotificationHandler from '#/../modules/expo-background-notification-handler'
 import {useAgeAssurance} from '#/ageAssurance'
 import {useAnalytics} from '#/analytics'
 import {IS_DEV, IS_NATIVE} from '#/env'
+import {AppSettings} from '#/indie-settings/settings'
 
 /**
  * @private
@@ -36,10 +37,18 @@ async function _registerPushToken({
   }
 }) {
   try {
-    const payload: AppBskyNotificationRegisterPush.InputSchema = {
-      serviceDid: currentAccount.service?.includes('staging')
+    const appview = getAppviewForAgent(agent)
+    const usingDefaultAppview =
+      appview.BSKY_SERVICE_DID === AppSettings.DEFAULT_BSKY_SERVICE_DID
+    // When a route matched, it already points to the correct appview for the
+    // account's PDS. Only apply the staging-vs-prod bluesky fallback when no
+    // route matched (i.e. we're on the default appview).
+    const serviceDid =
+      usingDefaultAppview && currentAccount.service?.includes('staging')
         ? PUBLIC_STAGING_APPVIEW_DID
-        : PUBLIC_APPVIEW_DID,
+        : appview.BSKY_SERVICE_DID
+    const payload: AppBskyNotificationRegisterPush.InputSchema = {
+      serviceDid,
       platform: Platform.OS,
       token: token.data,
       appId: 'xyz.blueskyweb.app',
@@ -301,11 +310,16 @@ export async function unregisterPushToken(agents: AtpAgent[]) {
     const token = await getPushToken()
     if (token) {
       for (const agent of agents) {
+        const appview = getAppviewForAgent(agent)
+        const usingDefaultAppview =
+          appview.BSKY_SERVICE_DID === AppSettings.DEFAULT_BSKY_SERVICE_DID
+        const serviceDid =
+          usingDefaultAppview && agent.serviceUrl.hostname.includes('staging')
+            ? PUBLIC_STAGING_APPVIEW_DID
+            : appview.BSKY_SERVICE_DID
         await agent.app.bsky.notification.unregisterPush(
           {
-            serviceDid: agent.serviceUrl.hostname.includes('staging')
-              ? PUBLIC_STAGING_APPVIEW_DID
-              : PUBLIC_APPVIEW_DID,
+            serviceDid,
             platform: Platform.OS,
             token: token.data,
             appId: 'xyz.blueskyweb.app',

--- a/src/lib/react-query.tsx
+++ b/src/lib/react-query.tsx
@@ -8,7 +8,7 @@ import {
   type PersistQueryClientProviderProps,
 } from '@tanstack/react-query-persist-client'
 
-import {PUBLIC_BSKY_SERVICE} from '#/lib/constants'
+import {DEFAULT_BSKY_SERVICE} from '#/lib/constants'
 import {createPersistedQueryStorage} from '#/lib/persisted-query-storage'
 import {listenNetworkConfirmed, listenNetworkLost} from '#/state/events'
 import {isQueryPersisted} from '#/state/queries/util'
@@ -28,7 +28,7 @@ async function checkIsOnline(): Promise<boolean> {
     setTimeout(() => {
       controller.abort()
     }, 15e3)
-    const res = await fetch(`${PUBLIC_BSKY_SERVICE}/xrpc/_health`, {
+    const res = await fetch(`${DEFAULT_BSKY_SERVICE}/xrpc/_health`, {
       cache: 'no-store',
       signal: controller.signal,
     })

--- a/src/state/queries/handle-availability.ts
+++ b/src/state/queries/handle-availability.ts
@@ -4,7 +4,7 @@ import {useQuery} from '@tanstack/react-query'
 import {
   BSKY_SERVICE,
   BSKY_SERVICE_DID,
-  PUBLIC_BSKY_SERVICE,
+  DEFAULT_BSKY_SERVICE,
 } from '#/lib/constants'
 import {useDebouncedValue} from '#/lib/hooks/useDebouncedValue'
 import {createFullHandle} from '#/lib/strings/handles'
@@ -111,7 +111,7 @@ export async function checkHandleAvailability(
     }
   } else {
     // 3rd party PDSes won't have this API so just try and resolve the handle
-    const agent = new Agent(null, {service: PUBLIC_BSKY_SERVICE})
+    const agent = new Agent(null, {service: DEFAULT_BSKY_SERVICE})
     try {
       const res = await agent.resolveHandle({
         handle,

--- a/src/state/session/__tests__/appview-proxy-test.ts
+++ b/src/state/session/__tests__/appview-proxy-test.ts
@@ -1,0 +1,94 @@
+import {describe, expect, it, jest} from '@jest/globals'
+
+jest.mock('jwt-decode', () => ({jwtDecode: () => ({})}))
+jest.mock('../../birthdate')
+jest.mock('../../../ageAssurance/data')
+jest.mock('#/lib/notifications/notifications', () => ({
+  unregisterPushToken: () => Promise.resolve(),
+}))
+
+import {AppSettings, type AppviewRoute} from '#/indie-settings/settings'
+import {configureAppviewProxy, getAppviewForAgent} from '../agent'
+
+type StubAgent = {
+  serviceUrl: string | URL | undefined
+  appview?: {BSKY_SERVICE: string; BSKY_SERVICE_DID: string}
+  configureProxy: jest.Mock
+}
+
+function makeAgent(serviceUrl: string | undefined): StubAgent {
+  return {
+    serviceUrl,
+    configureProxy: jest.fn(),
+  }
+}
+
+function withRoutes<T>(routes: AppviewRoute[], fn: () => T): T {
+  const original = AppSettings.APPVIEW_ROUTES
+  AppSettings.APPVIEW_ROUTES = routes
+  try {
+    return fn()
+  } finally {
+    AppSettings.APPVIEW_ROUTES = original
+  }
+}
+
+const routes: AppviewRoute[] = [
+  {
+    pdsHosts: ['host-one.test', 'host-two.test'],
+    BSKY_SERVICE: 'https://appview-a.test',
+    BSKY_SERVICE_DID: 'did:web:appview-a.test',
+  },
+]
+
+describe('configureAppviewProxy', () => {
+  it('resolves appview from the service URL hostname (not pdsUrl)', () => {
+    const agent = makeAgent('https://host-one.test')
+    withRoutes(routes, () => configureAppviewProxy(agent as any))
+    expect(agent.appview).toEqual({
+      BSKY_SERVICE: 'https://appview-a.test',
+      BSKY_SERVICE_DID: 'did:web:appview-a.test',
+    })
+    expect(agent.configureProxy).toHaveBeenCalledWith(
+      'did:web:appview-a.test#bsky_appview',
+    )
+  })
+
+  it('falls back to DEFAULT_BSKY_SERVICE when the service URL host does not match', () => {
+    const agent = makeAgent('https://unknown.test')
+    withRoutes(routes, () => configureAppviewProxy(agent as any))
+    expect(agent.appview).toEqual({
+      BSKY_SERVICE: AppSettings.DEFAULT_BSKY_SERVICE,
+      BSKY_SERVICE_DID: AppSettings.DEFAULT_BSKY_SERVICE_DID,
+    })
+    expect(agent.configureProxy).toHaveBeenCalledWith(
+      `${AppSettings.DEFAULT_BSKY_SERVICE_DID}#bsky_appview`,
+    )
+  })
+
+  it('matches additional hosts in the same route', () => {
+    const agent = makeAgent('https://host-two.test')
+    withRoutes(routes, () => configureAppviewProxy(agent as any))
+    expect(agent.appview?.BSKY_SERVICE).toBe('https://appview-a.test')
+  })
+})
+
+describe('getAppviewForAgent', () => {
+  it('returns the appview stored on the agent', () => {
+    const agent = {
+      appview: {
+        BSKY_SERVICE: 'https://appview-a.test',
+        BSKY_SERVICE_DID: 'did:web:appview-a.test',
+      },
+    }
+
+    expect(getAppviewForAgent(agent as any)).toEqual(agent.appview)
+  })
+
+  it('falls back to DEFAULT_BSKY_SERVICE when the agent has no appview', () => {
+    expect(getAppviewForAgent({} as any)).toEqual({
+      BSKY_SERVICE: AppSettings.DEFAULT_BSKY_SERVICE,
+      BSKY_SERVICE_DID: AppSettings.DEFAULT_BSKY_SERVICE_DID,
+    })
+  })
+})

--- a/src/state/session/__tests__/session-test.ts
+++ b/src/state/session/__tests__/session-test.ts
@@ -1,7 +1,7 @@
 import {BskyAgent} from '@atproto/api'
 import {describe, expect, it, jest} from '@jest/globals'
 
-import {PUBLIC_BSKY_SERVICE} from '#/lib/constants'
+import {DEFAULT_BSKY_SERVICE} from '#/lib/constants'
 import {agentToSessionAccountOrThrow} from '../agent'
 import {type Action, getInitialState, reducer, type State} from '../reducer'
 
@@ -27,7 +27,7 @@ describe('session', () => {
         "accounts": [],
         "currentAgentState": {
           "agent": {
-            "service": "${PUBLIC_BSKY_SERVICE}/",
+            "service": "${DEFAULT_BSKY_SERVICE}/",
           },
           "did": undefined,
         },
@@ -116,7 +116,7 @@ describe('session', () => {
         ],
         "currentAgentState": {
           "agent": {
-            "service": "${PUBLIC_BSKY_SERVICE}/",
+            "service": "${DEFAULT_BSKY_SERVICE}/",
           },
           "did": undefined,
         },
@@ -454,7 +454,7 @@ describe('session', () => {
         ],
         "currentAgentState": {
           "agent": {
-            "service": "${PUBLIC_BSKY_SERVICE}/",
+            "service": "${DEFAULT_BSKY_SERVICE}/",
           },
           "did": undefined,
         },
@@ -516,7 +516,7 @@ describe('session', () => {
         ],
         "currentAgentState": {
           "agent": {
-            "service": "${PUBLIC_BSKY_SERVICE}/",
+            "service": "${DEFAULT_BSKY_SERVICE}/",
           },
           "did": undefined,
         },
@@ -609,7 +609,7 @@ describe('session', () => {
         "accounts": [],
         "currentAgentState": {
           "agent": {
-            "service": "${PUBLIC_BSKY_SERVICE}/",
+            "service": "${DEFAULT_BSKY_SERVICE}/",
           },
           "did": undefined,
         },
@@ -789,7 +789,7 @@ describe('session', () => {
         ],
         "currentAgentState": {
           "agent": {
-            "service": "${PUBLIC_BSKY_SERVICE}/",
+            "service": "${DEFAULT_BSKY_SERVICE}/",
           },
           "did": undefined,
         },
@@ -1438,7 +1438,7 @@ describe('session', () => {
         ],
         "currentAgentState": {
           "agent": {
-            "service": "${PUBLIC_BSKY_SERVICE}/",
+            "service": "${DEFAULT_BSKY_SERVICE}/",
           },
           "did": undefined,
         },
@@ -1504,7 +1504,7 @@ describe('session', () => {
         ],
         "currentAgentState": {
           "agent": {
-            "service": "${PUBLIC_BSKY_SERVICE}/",
+            "service": "${DEFAULT_BSKY_SERVICE}/",
           },
           "did": undefined,
         },
@@ -1667,7 +1667,7 @@ describe('session', () => {
         ],
         "currentAgentState": {
           "agent": {
-            "service": "${PUBLIC_BSKY_SERVICE}/",
+            "service": "${DEFAULT_BSKY_SERVICE}/",
           },
           "did": undefined,
         },

--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -32,7 +32,11 @@ import {
   setCreatedAtForDid,
 } from '#/ageAssurance/data'
 import {features} from '#/analytics'
-import {AppSettings, resolveAppviewForPdsHost} from '#/indie-settings/settings'
+import {
+  AppSettings,
+  type Appview,
+  resolveAppviewForPdsHost,
+} from '#/indie-settings/settings'
 import {emitNetworkConfirmed, emitNetworkLost} from '../events'
 import {addSessionErrorLog} from './logging'
 import {
@@ -45,33 +49,30 @@ import {isSessionExpired, isSignupQueued} from './util'
 export type ProxyHeaderValue = `${Did}#${AtprotoServiceType}`
 
 /**
- * Resolved appview (service URL + DID) for an agent's account. Populated once
- * at login / session resume / account switch by {@link configureAppviewProxy}
- * and read by consumers via {@link useAppview}.
- */
-export interface Appview {
-  BSKY_SERVICE: string
-  BSKY_SERVICE_DID: string
-}
-
-/**
  * Configure the `atproto-proxy` header on `agent` so PDS requests for appview
- * lexicons are forwarded to the correct appview for the agent's PDS host,
- * and store the resolved appview on `agent.appview` for direct-to-appview
- * call sites (notifications, age assurance, ...).
+ * lexicons are forwarded to the correct appview for the hosting provider the
+ * user selected at login, and store the resolved appview on `agent.appview`
+ * for direct-to-appview call sites (notifications, age assurance, ...).
  *
- * The PDS host is determined from `agent.pdsUrl` (populated after login /
- * session resume) and matched against {@link IndieAppSettings.APPVIEW_ROUTES}.
- * If no route matches, the default appview is used. An E2E override via
- * {@link BLUESKY_PROXY_HEADER} takes precedence over the proxy header only;
- * `agent.appview` still reflects the resolved route.
+ * The hosting provider is `agent.serviceUrl` (what the user entered/selected
+ * as "Hosting provider" in the login form) and is matched against
+ * {@link IndieAppSettings.APPVIEW_ROUTES}. If no route matches, the default
+ * appview is used. An E2E override via {@link BLUESKY_PROXY_HEADER} takes
+ * precedence over the proxy header only; `agent.appview` still reflects the
+ * resolved route.
  */
-function configureAppviewProxy(agent: BskyAppAgent) {
-  const pdsHost = agent.pdsUrl?.hostname ?? new URL(agent.serviceUrl).hostname
+export function configureAppviewProxy(agent: BskyAppAgent) {
+  const pdsHost = agent.serviceUrl
+    ? new URL(agent.serviceUrl).hostname
+    : undefined
   const resolved = resolveAppviewForPdsHost(pdsHost)
   agent.appview = resolved
+  logger.debug('configureAppviewProxy', {
+    pdsHost,
+    appview: resolved.BSKY_SERVICE,
+  })
 
-  const override = BLUESKY_PROXY_HEADER.getOverride()
+  const override = BLUESKY_PROXY_HEADER.override
   if (override) {
     agent.configureProxy(override)
     return
@@ -532,6 +533,7 @@ class BskyAppAgent extends BskyAgent {
 }
 
 export type {BskyAppAgent}
+export type {Appview}
 
 /**
  * Returns the resolved appview for the given agent. Falls back to the default
@@ -539,16 +541,5 @@ export type {BskyAppAgent}
  * plain {@link Agent} used ad-hoc outside the session provider).
  */
 export function getAppviewForAgent(agent: BskyAgent | BaseAgent): Appview {
-  const candidate = (agent as unknown as {appview?: Appview}).appview
-  if (
-    candidate &&
-    typeof candidate.BSKY_SERVICE === 'string' &&
-    typeof candidate.BSKY_SERVICE_DID === 'string'
-  ) {
-    return candidate
-  }
-  return {
-    BSKY_SERVICE: AppSettings.DEFAULT_BSKY_SERVICE,
-    BSKY_SERVICE_DID: AppSettings.DEFAULT_BSKY_SERVICE_DID,
-  }
+  return (agent as BskyAppAgent).appview ?? resolveAppviewForPdsHost(undefined)
 }

--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -17,9 +17,9 @@ import {networkRetry} from '#/lib/async/retry'
 import {
   BLUESKY_PROXY_HEADER,
   BSKY_SERVICE,
+  DEFAULT_BSKY_SERVICE,
   DISCOVER_SAVED_FEED,
   IS_PROD_SERVICE,
-  PUBLIC_BSKY_SERVICE,
   TIMELINE_SAVED_FEED,
 } from '#/lib/constants'
 import {getAge} from '#/lib/strings/time'
@@ -32,7 +32,7 @@ import {
   setCreatedAtForDid,
 } from '#/ageAssurance/data'
 import {features} from '#/analytics'
-import {AppSettings} from '#/indie-settings/settings'
+import {AppSettings, resolveAppviewForPdsHost} from '#/indie-settings/settings'
 import {emitNetworkConfirmed, emitNetworkLost} from '../events'
 import {addSessionErrorLog} from './logging'
 import {
@@ -44,11 +44,48 @@ import {isSessionExpired, isSignupQueued} from './util'
 
 export type ProxyHeaderValue = `${Did}#${AtprotoServiceType}`
 
+/**
+ * Resolved appview (service URL + DID) for an agent's account. Populated once
+ * at login / session resume / account switch by {@link configureAppviewProxy}
+ * and read by consumers via {@link useAppview}.
+ */
+export interface Appview {
+  BSKY_SERVICE: string
+  BSKY_SERVICE_DID: string
+}
+
+/**
+ * Configure the `atproto-proxy` header on `agent` so PDS requests for appview
+ * lexicons are forwarded to the correct appview for the agent's PDS host,
+ * and store the resolved appview on `agent.appview` for direct-to-appview
+ * call sites (notifications, age assurance, ...).
+ *
+ * The PDS host is determined from `agent.pdsUrl` (populated after login /
+ * session resume) and matched against {@link IndieAppSettings.APPVIEW_ROUTES}.
+ * If no route matches, the default appview is used. An E2E override via
+ * {@link BLUESKY_PROXY_HEADER} takes precedence over the proxy header only;
+ * `agent.appview` still reflects the resolved route.
+ */
+function configureAppviewProxy(agent: BskyAppAgent) {
+  const pdsHost = agent.pdsUrl?.hostname ?? new URL(agent.serviceUrl).hostname
+  const resolved = resolveAppviewForPdsHost(pdsHost)
+  agent.appview = resolved
+
+  const override = BLUESKY_PROXY_HEADER.getOverride()
+  if (override) {
+    agent.configureProxy(override)
+    return
+  }
+  agent.configureProxy(
+    `${resolved.BSKY_SERVICE_DID}#bsky_appview` as ProxyHeaderValue,
+  )
+}
+
 export function createPublicAgent() {
   configureModerationForGuest() // Side effect but only relevant for tests
 
-  const agent = new BskyAppAgent({service: PUBLIC_BSKY_SERVICE})
-  agent.configureProxy(BLUESKY_PROXY_HEADER.get())
+  const agent = new BskyAppAgent({service: DEFAULT_BSKY_SERVICE})
+  configureAppviewProxy(agent)
   return agent
 }
 
@@ -80,7 +117,7 @@ export async function createAgentAndResume(
     ? prefetchAgeAssuranceData({agent})
     : Promise.resolve()
 
-  agent.configureProxy(BLUESKY_PROXY_HEADER.get())
+  configureAppviewProxy(agent)
 
   return agent.prepare({
     resolvers: [gates, moderation, aa],
@@ -121,7 +158,7 @@ export async function createAgentAndLogin(
     ? prefetchAgeAssuranceData({agent})
     : Promise.resolve()
 
-  agent.configureProxy(BLUESKY_PROXY_HEADER.get())
+  configureAppviewProxy(agent)
 
   return agent.prepare({
     resolvers: [gates, moderation, aa],
@@ -292,7 +329,7 @@ export async function createAgentAndCreateAccount(
     logger.error(e, {message: `session: failed snoozeEmailConfirmationPrompt`})
   }
 
-  agent.configureProxy(BLUESKY_PROXY_HEADER.get())
+  configureAppviewProxy(agent)
 
   return agent.prepare({
     resolvers: [gates, moderation, aa],
@@ -423,6 +460,15 @@ function stripProxyHeaderForPdsLocalLexicons(
 class BskyAppAgent extends BskyAgent {
   persistSessionHandler: ((event: AtpSessionEvent) => void) | undefined =
     undefined
+  /**
+   * Resolved appview for this agent's account. Defaults to the configured
+   * fallback; replaced with the route match (if any) by
+   * {@link configureAppviewProxy} once the PDS host is known.
+   */
+  appview: Appview = {
+    BSKY_SERVICE: AppSettings.DEFAULT_BSKY_SERVICE,
+    BSKY_SERVICE_DID: AppSettings.DEFAULT_BSKY_SERVICE_DID,
+  }
 
   constructor({service}: {service: string}) {
     super({
@@ -486,3 +532,23 @@ class BskyAppAgent extends BskyAgent {
 }
 
 export type {BskyAppAgent}
+
+/**
+ * Returns the resolved appview for the given agent. Falls back to the default
+ * appview when called with an agent that hasn't been configured (e.g. a
+ * plain {@link Agent} used ad-hoc outside the session provider).
+ */
+export function getAppviewForAgent(agent: BskyAgent | BaseAgent): Appview {
+  const candidate = (agent as unknown as {appview?: Appview}).appview
+  if (
+    candidate &&
+    typeof candidate.BSKY_SERVICE === 'string' &&
+    typeof candidate.BSKY_SERVICE_DID === 'string'
+  ) {
+    return candidate
+  }
+  return {
+    BSKY_SERVICE: AppSettings.DEFAULT_BSKY_SERVICE,
+    BSKY_SERVICE_DID: AppSettings.DEFAULT_BSKY_SERVICE_DID,
+  }
+}

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -18,10 +18,12 @@ import {IS_WEB} from '#/env'
 import {emitSessionDropped} from '../events'
 import {
   agentToSessionAccount,
+  type Appview,
   type BskyAppAgent,
   createAgentAndCreateAccount,
   createAgentAndLogin,
   createAgentAndResume,
+  getAppviewForAgent,
   sessionAccountToSession,
 } from './agent'
 import {type Action, getInitialState, reducer, type State} from './reducer'
@@ -457,4 +459,14 @@ export function useAgent(): AtpAgent {
     throw Error('useAgent() must be below <SessionProvider>.')
   }
   return agent
+}
+
+/**
+ * Returns the appview (service URL + DID) resolved for the current session's
+ * PDS at login / resume / account switch. Use this instead of the static
+ * `DEFAULT_BSKY_SERVICE` / `DEFAULT_BSKY_SERVICE_DID` constants whenever the
+ * call is scoped to the active account.
+ */
+export function useAppview(): Appview {
+  return getAppviewForAgent(useAgent())
 }


### PR DESCRIPTION
Rather then setting a default appview, we're going to take it a little further by introduce a routing function:

```ts
  APPVIEW_ROUTES: [
    {
      pdsHosts: ['blacksky.community', 'northsky.social'],
      BSKY_SERVICE: 'https://api.blacksky.community',
      BSKY_SERVICE_DID: 'did:web:api.blacksky.community',
    },
  ],
```

What this does, it matched by the PDS/entryway set during login and sets the Appview for the session. This allows us to enforce which appview a user goes to so we don't end up overloading an appview when everyone decides to use the social app and helps maintain a cohesive experience for communities built around a pds/appview. 

If a person signs in with a PDS that doesn't match then it will go to the configured fallback.