### PR TITLE
Show app name as default provider on login

### DIFF
--- a/src/components/dialogs/ServerInput.tsx
+++ b/src/components/dialogs/ServerInput.tsx
@@ -4,7 +4,7 @@ import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
 
-import {BSKY_SERVICE} from '#/lib/constants'
+import {APP_NAME, BSKY_SERVICE} from '#/lib/constants'
 import * as persisted from '#/state/persisted'
 import {useSession} from '#/state/session'
 import {atoms as a, platform, useBreakpoints, useTheme, web} from '#/alf'
@@ -141,9 +141,9 @@ function DialogInner({
           <SegmentedControl.Item
             testID="bskyServiceSelectBtn"
             value={BSKY_SERVICE}
-            label={_(msg`Bluesky`)}>
+            label={APP_NAME}>
             <SegmentedControl.ItemText>
-              {_(msg`Bluesky`)}
+              {APP_NAME}
             </SegmentedControl.ItemText>
           </SegmentedControl.Item>
           <SegmentedControl.Item

--- a/src/components/dialogs/ServerInput.tsx
+++ b/src/components/dialogs/ServerInput.tsx
@@ -142,9 +142,7 @@ function DialogInner({
             testID="bskyServiceSelectBtn"
             value={BSKY_SERVICE}
             label={APP_NAME}>
-            <SegmentedControl.ItemText>
-              {APP_NAME}
-            </SegmentedControl.ItemText>
+            <SegmentedControl.ItemText>{APP_NAME}</SegmentedControl.ItemText>
           </SegmentedControl.Item>
           <SegmentedControl.Item
             testID="customSelectBtn"

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -7,6 +7,7 @@ import {AppSettings} from '#/indie-settings/settings'
 
 export const LOCAL_DEV_SERVICE =
   Platform.OS === 'android' ? 'http://10.0.2.2:2583' : 'http://localhost:2583'
+export const APP_NAME = AppSettings.APP_NAME
 export const STAGING_SERVICE = AppSettings.STAGING_SERVICE
 export const BSKY_SERVICE = AppSettings.BSKY_SERVICE
 export const BSKY_SERVICE_DID = AppSettings.BSKY_SERVICE_DID


### PR DESCRIPTION
On sign in, the default provider name is hardcoded as "Bluesky" even though the default provider value is properly being fetched from settings.

This PR displays the app name as the provider to have both align.

## Before the change

<img width="626" height="349" alt="Screenshot 2026-05-08 at 3 44 45 PM" src="https://github.com/user-attachments/assets/dab6e08b-90fd-4d2c-b192-2b756e756070" />
<img width="648" height="196" alt="Screenshot 2026-05-08 at 3 44 56 PM" src="https://github.com/user-attachments/assets/c1037a44-5b64-45de-9f8d-f1aeddcf142c" />

## After the change
<img width="582" height="312" alt="Screenshot 2026-05-08 at 5 30 37 PM" src="https://github.com/user-attachments/assets/3159532c-a830-44c3-9fa8-04bb42ed8d3a" />
<img width="678" height="164" alt="Screenshot 2026-05-08 at 5 30 51 PM" src="https://github.com/user-attachments/assets/06ac9950-a1f1-4708-88a6-1a30c5b2277c" />

